### PR TITLE
FEATURE: implement tcp stats metrics

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+# Pull Request Template
+
+## Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B
+
+## Checklist:
+
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/internal/collector/protocol.go
+++ b/internal/collector/protocol.go
@@ -8,9 +8,14 @@ import (
 )
 
 type protocolCollector struct {
-	log       log.Logger
-	subsystem string
-	instance  string
+	log                       log.Logger
+	subsystem                 string
+	instance                  string
+	tcpConnectionCountByState *prometheus.Desc
+	tcpSentPackets            *prometheus.Desc
+	tcpReceivedPackets        *prometheus.Desc
+	arpSentRequests           *prometheus.Desc
+	arpReceivedRequests       *prometheus.Desc
 }
 
 func init() {
@@ -28,13 +33,68 @@ func (c *protocolCollector) Register(namespace, instanceLabel string, log log.Lo
 	c.instance = instanceLabel
 	level.Debug(c.log).
 		Log("msg", "Registering collector", "collector", c.Name())
+
+	c.tcpConnectionCountByState = buildPrometheusDesc(c.subsystem, "tcp_connection_count_by_state",
+		"Number of TCP connections by state",
+		[]string{"state"},
+	)
+
+	c.tcpSentPackets = buildPrometheusDesc(c.subsystem, "tcp_sent_packets_total",
+		"Number of sent TCP packets ",
+		nil,
+	)
+
+	c.tcpReceivedPackets = buildPrometheusDesc(c.subsystem, "tcp_received_packets_total",
+		"Number of received TCP packets",
+		nil,
+	)
+
+	c.arpSentRequests = buildPrometheusDesc(c.subsystem, "arp_sent_requests_total",
+		"Number of sent ARP requests",
+		nil,
+	)
+
+	c.arpReceivedRequests = buildPrometheusDesc(c.subsystem, "arp_received_requests_total",
+		"Number of received ARP requests",
+		nil,
+	)
 }
 
 func (c *protocolCollector) Describe(ch chan<- *prometheus.Desc) {
-
+	ch <- c.tcpConnectionCountByState
+	ch <- c.tcpSentPackets
+	ch <- c.tcpReceivedPackets
+	ch <- c.arpSentRequests
+	ch <- c.arpReceivedRequests
 }
 
 func (c *protocolCollector) Update(client *opnsense.Client, ch chan<- prometheus.Metric) *opnsense.APICallError {
+	data, err := client.FetchProtocolStatistics()
+	if err != nil {
+		return err
+	}
+
+	for state, count := range data.TCPConnectionCountByState {
+		ch <- prometheus.MustNewConstMetric(
+			c.tcpConnectionCountByState, prometheus.GaugeValue, float64(count), state, c.instance,
+		)
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		c.tcpSentPackets, prometheus.CounterValue, float64(data.TCPSentPackets), c.instance,
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.tcpReceivedPackets, prometheus.CounterValue, float64(data.TCPReceivedPackets), c.instance,
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.arpSentRequests, prometheus.CounterValue, float64(data.ARPSentRequests), c.instance,
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		c.arpReceivedRequests, prometheus.CounterValue, float64(data.ARPReceivedRequests), c.instance,
+	)
 
 	return nil
 }

--- a/internal/options/ops.go
+++ b/internal/options/ops.go
@@ -88,6 +88,7 @@ func opsAPIKey() (string, error) {
 	return *opnsenseAPIKey, nil
 }
 
+// OPNSenseConfig holds the configuration for the OPNsense API.
 type OPNSenseConfig struct {
 	Protocol  string
 	Host      string
@@ -96,11 +97,8 @@ type OPNSenseConfig struct {
 	Insecure  bool
 }
 
-func (c *OPNSenseConfig) String() string {
-	return fmt.Sprintf("Protocol: %s, Host: %s, APIKey: %s, APISecret: %s, Insecure: %t",
-		c.Protocol, c.Host, c.APIKey, c.APISecret, c.Insecure)
-}
-
+// Validate checks if the configuration is valid.
+// returns an error on any missing value
 func (c *OPNSenseConfig) Validate() error {
 	if c.Protocol != "http" && c.Protocol != "https" {
 		return fmt.Errorf("protocol must be one of: [http, https]")

--- a/opnsense/unbound_dns.go
+++ b/opnsense/unbound_dns.go
@@ -233,11 +233,11 @@ func (c *Client) FetchUnboundOverview() (UnboundDNSOverview, *APICallError) {
 		}
 	}
 	data.AnnswerBogusTotal, errConvertion = parseStringToInt(response.Data.Num.Answer.Bogus, url)
-	if err != nil {
+	if errConvertion != nil {
 		return data, errConvertion
 	}
 	data.AnswerSecureTotal, errConvertion = parseStringToInt(response.Data.Num.Answer.Secure, url)
-	if err != nil {
+	if errConvertion != nil {
 		return data, errConvertion
 	}
 	return data, nil


### PR DESCRIPTION
This PR implements a set of common TCP metrics exposed by OPNsense

Example: 

```text
# HELP opnsense_proto_statistics_arp_received_requests_total Number of received ARP requests
# TYPE opnsense_proto_statistics_arp_received_requests_total counter
opnsense_proto_statistics_arp_received_requests_total{opnsense_instance="opnsense-local1"} 6.526501e+06
# HELP opnsense_proto_statistics_arp_sent_requests_total Number of sent ARP requests
# TYPE opnsense_proto_statistics_arp_sent_requests_total counter
opnsense_proto_statistics_arp_sent_requests_total{opnsense_instance="opnsense-local1"} 11673
# HELP opnsense_proto_statistics_tcp_connection_count_by_state Number of TCP connections by state
# TYPE opnsense_proto_statistics_tcp_connection_count_by_state gauge
opnsense_proto_statistics_tcp_connection_count_by_state{opnsense_instance="opnsense-local1",state="CLOSED"} 0
opnsense_proto_statistics_tcp_connection_count_by_state{opnsense_instance="opnsense-local1",state="CLOSE_WAIT"} 0
opnsense_proto_statistics_tcp_connection_count_by_state{opnsense_instance="opnsense-local1",state="CLOSING"} 0
opnsense_proto_statistics_tcp_connection_count_by_state{opnsense_instance="opnsense-local1",state="ESTABLISHED"} 6
opnsense_proto_statistics_tcp_connection_count_by_state{opnsense_instance="opnsense-local1",state="FIN_WAIT_1"} 0
opnsense_proto_statistics_tcp_connection_count_by_state{opnsense_instance="opnsense-local1",state="FIN_WAIT_2"} 0
opnsense_proto_statistics_tcp_connection_count_by_state{opnsense_instance="opnsense-local1",state="LAST_ACK"} 0
opnsense_proto_statistics_tcp_connection_count_by_state{opnsense_instance="opnsense-local1",state="LISTEN"} 37
opnsense_proto_statistics_tcp_connection_count_by_state{opnsense_instance="opnsense-local1",state="SYN_RCVD"} 0
opnsense_proto_statistics_tcp_connection_count_by_state{opnsense_instance="opnsense-local1",state="SYN_SENT"} 0
opnsense_proto_statistics_tcp_connection_count_by_state{opnsense_instance="opnsense-local1",state="TIME_WAIT"} 12
# HELP opnsense_proto_statistics_tcp_received_packets_total Number of received TCP packets
# TYPE opnsense_proto_statistics_tcp_received_packets_total counter
opnsense_proto_statistics_tcp_received_packets_total{opnsense_instance="opnsense-local1"} 1.23587e+07
# HELP opnsense_proto_statistics_tcp_sent_packets_total Number of sent TCP packets 
# TYPE opnsense_proto_statistics_tcp_sent_packets_total counter
opnsense_proto_statistics_tcp_sent_packets_total{opnsense_instance="opnsense-local1"} 1.6408881e+07
```

Introduce pull_req_template as well