### PR TITLE
Changes CMD for ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ COPY . .
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
     go build \
-	    -tags osusergo,netgo \
-	    -ldflags "-s -w -X main.version=${Version}" \
-        -o /usr/bin/opnsense-exporter .
+    -tags osusergo,netgo \
+    -ldflags "-s -w -X main.version=${Version}" \
+    -o /usr/bin/opnsense-exporter .
 
 FROM --platform=${BUILDPLATFORM:-linux/amd64} gcr.io/distroless/static-debian12:latest
 
@@ -24,4 +24,4 @@ LABEL org.opencontainers.image.title="OPNsense Prometheus Exporter"
 LABEL org.opencontainers.image.description="Prometheus exporter for OPNsense"
 
 COPY --from=build /usr/bin/opnsense-exporter /
-CMD ["/opnsense-exporter"]
+ENTRYPOINT ["/opnsense-exporter"]

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ services:
     container_name: opensense-exporter
     restart: always
     command:
-      - /opnsense-exporter
       - --opnsense.protocol=https
       - --opnsense.address=ops.example.com
       - --exporter.instance-label=instance1
@@ -102,7 +101,6 @@ services:
     container_name: opensense-exporter
     restart: always
     command:
-      - /opnsense-exporter
       - --opnsense.protocol=https
       - --opnsense.address=ops.example.com
       - --exporter.instance-label=instance1


### PR DESCRIPTION

## Description

`ENTRYPOINT` is the binary that should be run when the container is created and  `CMD` is for any default arguments that should be supplied to the binary.

Since the instance label is required and no default is set, you could do something like this:

```Dockerfile
ENTRYPOINT ["/opnsense-exporter"]
CMD [ "--exporter.instance-label=myFireWall" ]
```

but i'm not sure if you'd prefer to set the default value in the binary / where you parse CLI args or if requiring the user to explicitly set the instance label is the goal.


In any case, for a (slightly) simpler k8s deployment/config, the CMD -> ENTRYPOINT change needs to be made :).


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

