### PR TITLE
FIX: health check; flags; metrics list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ go.work
 local.Makefile
 key
 secret
+local.docker-compose.yml

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The missing OPNsense exporter for Prometheus
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/AthennaMind/opnsense-exporter/ci.yml)
 ![GitHub go.mod Go version (branch)](https://img.shields.io/github/go-mod/go-version/AthennaMind/opnsense-exporter/main)
 
-`Still under heavy development. The full metrics list is not yet implemented.`
+`Still under heavy development. The full metrics list is not yet implemented. May include breaking changes of the configuration and metrics list.`
 
 ## Table of Contents
 
@@ -155,6 +155,7 @@ Gathering metrics for specific subsystems can be disabled with the following fla
 - `--exporter.disable-cron-table` - Disable the scraping of Cron tasks. Defaults to `false`.
 - `--exporter.disable-wireguard` - Disable the scraping of Wireguard service. Defaults to `false`.
 - `--exporter.disable-unbound` - Disable the scraping of Unbound service. Defaults to `false`.
+- `--exporter.disable-openvpn` - Disable the scraping of OpenVPN service. Defaults to `false`.
 
 To disable the exporter metrics itself use the following flag:
 
@@ -178,6 +179,9 @@ Flags:
       --[no-]exporter.disable-unbound
                                  Disable the scraping of Unbound service
                                  ($OPNSENSE_EXPORTER_DISABLE_UNBOUND)
+      --[no-]exporter.disable-openvpn
+                                  Disable the scraping of OpenVPN service
+                                  ($OPNSENSE_EXPORTER_DISABLE_OPENVPN)
       --web.telemetry-path="/metrics"
                                  Path under which to expose metrics.
       --[no-]web.disable-exporter-metrics

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -28,7 +28,7 @@ opnsense_services_status | Gauge | name, description | Services | Service status
 | Metric Name | Type | Labels | Subsystem | Description | Disable Flag |
 | --- | --- | --- | --- | --- | --- |
 opnsense_interfaces_mtu_bytes | Gauge | interface, device, type | Interfaces | MTU of the interface by interface name and device | n/a |
-opnsese_interfaces_received_bytes_total | Counter | interface, device, type | Interfaces | Total number of received bytes on this interface by interface name and device | n/a |
+opnsense_interfaces_received_bytes_total | Counter | interface, device, type | Interfaces | Total number of received bytes on this interface by interface name and device | n/a |
 opnsense_interfaces_transmitted_bytes_total | Counter | interface, device, type | Interfaces | Total number of transmitted bytes on this interface by interface name and device | n/a |
 opnsense_interfaces_received_multicasts_total | Counter | interface, device, type | Interfaces | Total number of received multicast packets on this interface by interface name and device | n/a |
 opnsense_interfaces_transmitted_multicasts_total | Counter | interface, device, type | Interfaces | Total number of transmitted multicast packets on this interface by interface name and device | n/a |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -3,20 +3,62 @@
 This table represent each metric and it's labels, the subsystem that it belongs, its description and how to disable it. The opnsense_instance label is applied to all metrics.
 
 
+### General 
+
 | Metric Name | Type | Labels | Subsystem | Description | Disable Flag |
 | --- | --- | --- | --- | --- | --- |
 opnsense_up | Gauge | opnsense_instance | n/a | The current status of OPNsense (1 = up, 0 = down) | n/a |
+opnsense_firewall_status | Gauge | opnsense_instance | n/a | Status of the firewall reported by `api/core/system/status` ( 1 = ok, 0 = errors) | n/a |
 opnsense_exporter_scrapes_total | Counter | n/a | n/a | Total number of scrapes by the OPNsense exporter | n/a |
 opnsense_exporter_endpoint_errors_total | Counter | endpoint | n/a | Total number of errors by endpoint returned by the OPNsense API during data fetching | n/a |
-opnsense_arp_table_entries | Gauge | expired, hostname, interface_description, ip, mac, permanent, type | ARP Table | Arp entries by ip, mac, hostname, interface description, type, expired and permanent | --exporter.disable-arp-table |
 opnsense_cron_job_status | Gauge | command, description, origin, schedule | Cron Table | Cron job status by name and description (1 = enabled, 0 = disabled) | --exporter.disable-cron-table |
+
+
+### Services 
+
+| Metric Name | Type | Labels | Subsystem | Description | Disable Flag |
+| --- | --- | --- | --- | --- | --- |
+opnsense_services_running_total | Gauge | n/a | Services | Total number of running services | n/a |
+opnsense_services_stopped_total | Gauge | n/a | Services | Total number of stopped services | n/a |
+opnsense_services_status | Gauge | name, description | Services | Service status by name and description (1 = running, 0 = stopped) | n/a |
+
+
+### Interfaces
+
+| Metric Name | Type | Labels | Subsystem | Description | Disable Flag |
+| --- | --- | --- | --- | --- | --- |
+opnsense_interfaces_mtu_bytes | Gauge | interface, device, type | Interfaces | MTU of the interface by interface name and device | n/a |
+opnsese_interfaces_received_bytes_total | Counter | interface, device, type | Interfaces | Total number of received bytes on this interface by interface name and device | n/a |
+opnsense_interfaces_transmitted_bytes_total | Counter | interface, device, type | Interfaces | Total number of transmitted bytes on this interface by interface name and device | n/a |
+opnsense_interfaces_received_multicasts_total | Counter | interface, device, type | Interfaces | Total number of received multicast packets on this interface by interface name and device | n/a |
+opnsense_interfaces_transmitted_multicasts_total | Counter | interface, device, type | Interfaces | Total number of transmitted multicast packets on this interface by interface name and device | n/a |
+opnsense_interfaces_input_errors_total | Counter | interface, device, type | Interfaces | Input errors on this interface by interface name and device | n/a |
+opnsense_interfaces_output_errors_total | Counter | interface, device, type | Interfaces | Output errors on this interface by interface name and device | n/a |
+opnsense_interfaces_collisions_total | Counter | interface, device, type | Interfaces | Collisions on this interface by interface name and device | n/a |
+
+### ARP
+
+| Metric Name | Type | Labels | Subsystem | Description | Disable Flag |
+| --- | --- | --- | --- | --- | --- |
+opnsense_arp_table_entries | Gauge | expired, hostname, interface_description, ip, mac, permanent, type | ARP Table | Arp entries by ip, mac, hostname, interface description, type, expired and permanent | --exporter.disable-arp-table |
+opnsense_protocol_arp_sent_requests_total | Counter | n/a | Protocol Statistics | Total Number of sent ARP requests  | n/a |
+opnsense_protocol_arp_received_requests_total | Counter | n/a | Protocol Statistics | Total Number of received ARP requests  | n/a |
+
+
+### Gateways
+
+| Metric Name | Type | Labels | Subsystem | Description | Disable Flag |
+| --- | --- | --- | --- | --- | --- |
 opnsense_gateways_status | Gauge | address, name | Gateways | Status of the gateway by name and address (1 = up, 0 = down, 2 = unknown) | n/a |
 opnsense_gateways_loss_percentage | Gauge | address, name | Gateways | The current gateway loss percentage by name and address | n/a |
 opnsense_gateways_rtt_milliseconds | Gauge | address, name | Gateways | RTT is the average (mean) of the round trip time in milliseconds by name and address | n/a |
 opnsense_gateways_rttd_milliseconds | Gauge | address, name | Gateways | RTTd is the standard deviation of the round trip time in milliseconds by name and address | n/a |
-opnsense_openvpn_instances | Gauge | description, device_type, role, uuid | OpenVPN | OpenVPN instances (1 = enabled, 0 = disabled) by role (server, client) | n/a |
-opnsense_protocol_arp_sent_requests_total | Counter | n/a | Protocol Statistics | Total Number of sent ARP requests  | n/a |
-opnsense_protocol_arp_received_requests_total | Counter | n/a | Protocol Statistics | Total Number of received ARP requests  | n/a |
+
+
+### Protocol Statistics
+
+| Metric Name | Type | Labels | Subsystem | Description | Disable Flag |
+| --- | --- | --- | --- | --- | --- |
 opnsense_protocol_tcp_sent_packets_total | Counter | n/a | Protocol Statistics | Total Number of sent TCP packets  | n/a |
 opnsense_protocol_tcp_received_packets_total | Counter | n/a | Protocol Statistics | Total Number of received TCP packets | n/a |
 opnsense_protocol_tcp_connection_count_by_state | Gauge | state | Protocol Statistics | Number of TCP connections by state | n/a |
@@ -27,7 +69,26 @@ opnsense_protocol_udp_dropped_by_reason_total | CounterVector | reason | Protoco
 opnsense_protocol_icmp_calls_total | Counter | n/a | Protocol Statistics | Total Number of ICMP calls | n/a |
 opnsense_protocol_icmp_sent_packets_total | Counter | n/a | Protocol Statistics | Total Number of sent ICMP packets | n/a |
 opnsense_protocol_icmp_dropped_by_reason_total | CounterVector | reason | Protocol Statistics | Total Number of dropped ICMP packets by reason | n/a |
-opnsense_services_running_total | Gauge | n/a | Services | Total number of running services | n/a |
-opnsense_services_stopped_total | Gauge | n/a | Services | Total number of stopped services | n/a |
-opnsense_services_status | Gauge | name, description | Services | Service status by name and description (1 = running, 0 = stopped) | n/a |
+
+
+
+### Unbound DNS
+
+| Metric Name | Type | Labels | Subsystem | Description | Disable Flag |
+| --- | --- | --- | --- | --- | --- |
 opnsense_unbound_dns_uptime_seconds | Gauge | n/a | Unbound | Uptime of the unbound DNS service in seconds | --exporter.disable-unbound |
+
+### Wireguard 
+
+| Metric Name | Type | Labels | Subsystem | Description | Disable Flag |
+| --- | --- | --- | --- | --- | --- |
+opnsense_wireguard_interfaces_status | Gauge | name, description, public_key | Wireguard | Wireguard interfaces status by name, description and public key (1 = up, 0 = down) | --exporter.disable-wireguard  |
+opnsense_wireguard_peer_received_bytes_total | Counter | device, device_type, device_name, peer_name | Wireguard | Bytes received by this wireguard peer | --exporter.disable-wireguard  |
+opnsense_wireguard_peer_transmitted_bytes_total | Counter | device, device_type, device_name, peer_name | Wireguard | Bytes transmitted by this wireguard peer | --exporter.disable-wireguard  |
+opnsense_wireguard_peer_last_handshake_seconds | Gauge | device, device_type, device_name, peer_name | Wireguard | Last handshake time in seconds by this wireguard peer | --exporter.disable-wireguard  |
+
+### OpenVPN
+
+| Metric Name | Type | Labels | Subsystem | Description | Disable Flag |
+| --- | --- | --- | --- | --- | --- |
+opnsense_openvpn_instances | Gauge | description, device_type, role, uuid | OpenVPN | OpenVPN instances (1 = enabled, 0 = disabled) by role (server, client) | --exporter.disable-openvpn |

--- a/internal/options/collectors.go
+++ b/internal/options/collectors.go
@@ -19,6 +19,10 @@ var (
 		"exporter.disable-unbound",
 		"Disable the scraping of Unbound service",
 	).Envar("OPNSENSE_EXPORTER_DISABLE_UNBOUND").Default("false").Bool()
+	openVPNCollectorDisabled = kingpin.Flag(
+		"exporter.disable-openvpn",
+		"Disable the scraping of OpenVPN service",
+	).Envar("OPNSENSE_EXPORTER_DISABLE_OPENVPN").Default("false").Bool()
 )
 
 // CollectorsDisableSwitch hold the enabled/disabled state of the collectors
@@ -27,6 +31,7 @@ type CollectorsDisableSwitch struct {
 	Cron      bool
 	Wireguard bool
 	Unbound   bool
+	OpenVPN   bool
 }
 
 // CollectorsSwitches returns configured instances of CollectorsDisableSwitch
@@ -36,5 +41,6 @@ func CollectorsSwitches() CollectorsDisableSwitch {
 		Cron:      !*cronTableCollectorDisabled,
 		Wireguard: !*wireguardCollectorDisabled,
 		Unbound:   !*unboundCollectorDisabled,
+		OpenVPN:   !*openVPNCollectorDisabled,
 	}
 }

--- a/opnsense/health_check.go
+++ b/opnsense/health_check.go
@@ -2,18 +2,14 @@ package opnsense
 
 type HealthCheckResponse struct {
 	CrashReporter struct {
-		StatusCode  int    `json:"statusCode"`
-		Message     string `json:"message"`
-		LogLocation string `json:"logLocation"`
-		Timestamp   string `json:"timestamp"`
-		Status      string `json:"status"`
+		StatusCode int    `json:"statusCode"`
+		Message    string `json:"message"`
+		Status     string `json:"status"`
 	} `json:"CrashReporter"`
 	Firewall struct {
-		StatusCode  int    `json:"statusCode"`
-		Message     string `json:"message"`
-		LogLocation string `json:"logLocation"`
-		Timestamp   string `json:"timestamp"`
-		Status      string `json:"status"`
+		StatusCode int    `json:"statusCode"`
+		Message    string `json:"message"`
+		Status     string `json:"status"`
 	} `json:"Firewall"`
 	System struct {
 		Status string `json:"status"`

--- a/opnsense/utils.go
+++ b/opnsense/utils.go
@@ -18,7 +18,7 @@ func parseStringToInt(value string, endpoint EndpointPath) (int, *APICallError) 
 	if err != nil {
 		return 0, &APICallError{
 			Endpoint:   string(endpoint),
-			Message:    fmt.Sprintf("error parsing %s to int: %s", value, err.Error()),
+			Message:    fmt.Sprintf("error parsing '%s' to int: %s", value, err.Error()),
 			StatusCode: 0,
 		}
 	}


### PR DESCRIPTION
# Fix health checks and improve metrics list documentation

## Description

This PR:

- removes some unused fields in the health check response that had the potential to broke the marshaling. See #18  
- add disable flag for OpenVPN 
- document the full metrics list in `docs/metrics.md`
- introduce firewall health check metrics 

Fixes #18 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] I have updated the docs/metrics.md file, when I introduced new metrics
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules