### PR TITLE
feat: Collect more gateway information

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -84,10 +84,19 @@ opnsense_protocol_arp_received_requests_total | Counter | n/a | Protocol Statist
 
 | Metric Name | Type | Labels | Subsystem | Description | Disable Flag |
 | --- | --- | --- | --- | --- | --- |
-opnsense_gateways_status | Gauge | address, name | Gateways | Status of the gateway by name and address (1 = up, 0 = down, 2 = unknown) | n/a |
+opnsense_gateways_info | Gauge | name, description, device, protocol, enabled, weight, interface, upstream | Gateways | Configuration details of the gateway | n/a |
+opnsense_gateways_monitor_info | Gauge | name, enabled, no_route, address | Gateways | Configuration details of the gateway monitoring | n/a |
+opnsense_gateways_status | Gauge | address, name | Gateways | Status of the gateway by name and address (1 = up, 0 = down, 2 = unknown, 3 = pending) | n/a |
 opnsense_gateways_loss_percentage | Gauge | address, name | Gateways | The current gateway loss percentage by name and address | n/a |
 opnsense_gateways_rtt_milliseconds | Gauge | address, name | Gateways | RTT is the average (mean) of the round trip time in milliseconds by name and address | n/a |
 opnsense_gateways_rttd_milliseconds | Gauge | address, name | Gateways | RTTd is the standard deviation of the round trip time in milliseconds by name and address | n/a |
+opnsense_gateways_rtt_low_milliseconds | Gauge | address, name | Gateways | Lower threshold for the round trip time in milliseconds by name and address | n/a |
+opnsense_gateways_rtt_high_milliseconds | Gauge | address, name | Gateways | Upper threshold for the round trip time in milliseconds by name and address | n/a |
+opnsense_gateways_loss_low_percentage | Gauge | address, name | Gateways | Lower threshold for the packet loss ratio by name and address | n/a |
+opnsense_gateways_loss_high_percentage | Gauge | address, name | Gateways | Upper threshold for the packet loss ratio by name and address | n/a |
+opnsense_gateways_probe_interval_seconds | Gauge | address, name | Gateways | Monitoring probe interval duration by name and address | n/a |
+opnsense_gateways_probe_period_seconds | Gauge | address, name | Gateways | Monitoring probe period over which results are averaged by name and address | n/a |
+opnsense_gateways_probe_timeout_seconds | Gauge | address, name | Gateways | Monitoring probe timeout by name and address | n/a |
 
 ### Protocol Statistics
 

--- a/internal/collector/gateways.go
+++ b/internal/collector/gateways.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"log/slog"
+	"strconv"
 
 	"github.com/AthennaMind/opnsense-exporter/opnsense"
 	"github.com/prometheus/client_golang/prometheus"
@@ -9,18 +10,29 @@ import (
 
 type gatewaysCollector struct {
 	log            *slog.Logger
-	status         *prometheus.Desc
-	lossPercentage *prometheus.Desc
+	info           *prometheus.Desc
+	monitor        *prometheus.Desc
 	rtt            *prometheus.Desc
 	rttd           *prometheus.Desc
+	rttLow         *prometheus.Desc
+	rttHigh        *prometheus.Desc
+	lossPercentage *prometheus.Desc
+	lossLow        *prometheus.Desc
+	lossHigh       *prometheus.Desc
+	interval       *prometheus.Desc
+	period         *prometheus.Desc
+	timeout        *prometheus.Desc
+	status         *prometheus.Desc
 	subsystem      string
 	instance       string
 }
 
 func init() {
-	collectorInstances = append(collectorInstances, &gatewaysCollector{
-		subsystem: GatewaysSubsystem,
-	})
+	collectorInstances = append(collectorInstances,
+		&gatewaysCollector{
+			subsystem: GatewaysSubsystem,
+		},
+	)
 }
 
 func (c *gatewaysCollector) Name() string {
@@ -32,14 +44,14 @@ func (c *gatewaysCollector) Register(namespace, instanceLabel string, log *slog.
 	c.instance = instanceLabel
 	c.log.Debug("Registering collector", "collector", c.Name())
 
-	c.status = buildPrometheusDesc(c.subsystem, "status",
-		"Status of the gateway by name and address (1 = up, 0 = down, 2 = unknown)",
-		[]string{"name", "address"},
+	c.info = buildPrometheusDesc(c.subsystem, "info",
+		"Information of the gateway",
+		[]string{"name", "description", "device", "protocol", "enabled", "weight", "interface", "upstream"},
 	)
-	c.lossPercentage = buildPrometheusDesc(
-		c.subsystem, "loss_percentage",
-		"The current gateway loss percentage by name and address",
-		[]string{"name", "address"},
+	c.monitor = buildPrometheusDesc(
+		c.subsystem, "monitor_info",
+		"Gateway monitoring configuration",
+		[]string{"name", "enabled", "no_route", "address"},
 	)
 	c.rtt = buildPrometheusDesc(
 		c.subsystem, "rtt_milliseconds",
@@ -49,6 +61,50 @@ func (c *gatewaysCollector) Register(namespace, instanceLabel string, log *slog.
 	c.rttd = buildPrometheusDesc(
 		c.subsystem, "rttd_milliseconds",
 		"RTTd is the standard deviation of the round trip time in milliseconds by name and address",
+		[]string{"name", "address"},
+	)
+	c.rttLow = buildPrometheusDesc(
+		c.subsystem, "rtt_low_milliseconds",
+		"Gateway low latency threshold",
+		[]string{"name", "address"},
+	)
+	c.rttHigh = buildPrometheusDesc(
+		c.subsystem, "rtt_high_milliseconds",
+		"Gateway high latency threshold",
+		[]string{"name", "address"},
+	)
+	c.lossPercentage = buildPrometheusDesc(
+		c.subsystem, "loss_percentage",
+		"The current gateway loss percentage by name and address",
+		[]string{"name", "address"},
+	)
+	c.lossLow = buildPrometheusDesc(
+		c.subsystem, "loss_low_percentage",
+		"Gateway low packet loss threshold",
+		[]string{"name", "address"},
+	)
+	c.lossHigh = buildPrometheusDesc(
+		c.subsystem, "loss_high_percentage",
+		"Gateway high packet loss threshold",
+		[]string{"name", "address"},
+	)
+	c.interval = buildPrometheusDesc(
+		c.subsystem, "probe_interval_seconds",
+		"Gateway probe interval",
+		[]string{"name", "address"},
+	)
+	c.period = buildPrometheusDesc(
+		c.subsystem, "probe_period_seconds",
+		"Gateway probe period",
+		[]string{"name", "address"},
+	)
+	c.timeout = buildPrometheusDesc(
+		c.subsystem, "probe_timeout_seconds",
+		"Gateway probe timeout",
+		[]string{"name", "address"},
+	)
+	c.status = buildPrometheusDesc(c.subsystem, "status",
+		"Status of the gateway by name and address (0 = Offline, 1 = Online, 2 = Unknown, 3 = Pending)",
 		[]string{"name", "address"},
 	)
 }
@@ -65,43 +121,128 @@ func (c *gatewaysCollector) Update(client *opnsense.Client, ch chan<- prometheus
 		return err
 	}
 	for _, v := range data.Gateways {
+		monitorEnabledFloat := 1.0
+		if !v.MonitorEnabled {
+			monitorEnabledFloat = 0.0
+		}
+		interfaceEnabledFloat := 1.0
+		if !v.Enabled {
+			interfaceEnabledFloat = 0.0
+		}
+
 		ch <- prometheus.MustNewConstMetric(
-			c.status,
+			c.info,
 			prometheus.GaugeValue,
-			float64(v.Status),
+			interfaceEnabledFloat,
 			v.Name,
-			v.Address,
+			v.Description,
+			v.Interface,
+			v.IPProtocol,
+			strconv.FormatBool(v.Enabled),
+			v.Weight,
+			v.HardwareInterface,
+			strconv.FormatBool(v.Upstream),
 			c.instance,
 		)
-		if v.LossPercentage != -1 {
+		if v.Enabled {
 			ch <- prometheus.MustNewConstMetric(
-				c.lossPercentage,
+				c.monitor,
 				prometheus.GaugeValue,
-				float64(v.LossPercentage),
+				monitorEnabledFloat,
 				v.Name,
-				v.Address,
+				strconv.FormatBool(v.MonitorEnabled),
+				strconv.FormatBool(v.MonitorNoRoute),
+				v.Monitor,
 				c.instance,
 			)
-		}
-		if v.RTTMilliseconds != -1 {
-			ch <- prometheus.MustNewConstMetric(
-				c.rtt,
-				prometheus.GaugeValue,
-				v.RTTMilliseconds,
-				v.Name,
-				v.Address,
-				c.instance,
-			)
-		}
-		if v.RTTDMilliseconds != -1 {
-			ch <- prometheus.MustNewConstMetric(
-				c.rttd,
-				prometheus.GaugeValue,
-				v.RTTDMilliseconds,
-				v.Name,
-				v.Address,
-				c.instance,
-			)
+			if v.MonitorEnabled {
+				ch <- prometheus.MustNewConstMetric(
+					c.rtt,
+					prometheus.GaugeValue,
+					v.Delay,
+					v.Name,
+					v.Monitor,
+					c.instance,
+				)
+				ch <- prometheus.MustNewConstMetric(
+					c.rttd,
+					prometheus.GaugeValue,
+					v.StdDev,
+					v.Name,
+					v.Monitor,
+					c.instance,
+				)
+				f64, _ := strconv.ParseFloat(v.LatencyLow, 64)
+				ch <- prometheus.MustNewConstMetric(
+					c.rttLow,
+					prometheus.GaugeValue,
+					f64,
+					v.Name,
+					v.Monitor,
+					c.instance,
+				)
+				f64, _ = strconv.ParseFloat(v.LatencyHigh, 64)
+				ch <- prometheus.MustNewConstMetric(
+					c.rttHigh,
+					prometheus.GaugeValue,
+					f64,
+					v.Name,
+					v.Monitor,
+					c.instance,
+				)
+				ch <- prometheus.MustNewConstMetric(
+					c.lossPercentage,
+					prometheus.GaugeValue,
+					v.Loss,
+					v.Name,
+					v.Monitor,
+					c.instance,
+				)
+				f64, _ = strconv.ParseFloat(v.LossLow, 64)
+				ch <- prometheus.MustNewConstMetric(
+					c.lossLow,
+					prometheus.GaugeValue,
+					f64,
+					v.Name,
+					v.Monitor,
+					c.instance,
+				)
+				f64, _ = strconv.ParseFloat(v.LossHigh, 64)
+				ch <- prometheus.MustNewConstMetric(
+					c.lossHigh,
+					prometheus.GaugeValue,
+					f64,
+					v.Name,
+					v.Monitor,
+					c.instance,
+				)
+				f64, _ = strconv.ParseFloat(v.Interval, 64)
+				ch <- prometheus.MustNewConstMetric(
+					c.interval,
+					prometheus.GaugeValue,
+					f64,
+					v.Name,
+					v.Monitor,
+					c.instance,
+				)
+				f64, _ = strconv.ParseFloat(v.LossInterval, 64)
+				ch <- prometheus.MustNewConstMetric(
+					c.timeout,
+					prometheus.GaugeValue,
+					f64,
+					v.Name,
+					v.Monitor,
+					c.instance,
+				)
+				ch <- prometheus.MustNewConstMetric(
+					c.status,
+					prometheus.GaugeValue,
+					float64(v.Status),
+					v.Name,
+					v.Monitor,
+					c.instance,
+				)
+			}
 		}
 	}
 	return nil

--- a/internal/collector/utils.go
+++ b/internal/collector/utils.go
@@ -18,3 +18,9 @@ func buildPrometheusDesc(subsystem, name, help string, labels []string) *prometh
 		nil,
 	)
 }
+
+// parseStringToBool parses a string value to a bool value.
+// The value is considered true if it is not "0".
+func parseStringToBool(value string) bool {
+	return value != "0"
+}

--- a/opnsense/client.go
+++ b/opnsense/client.go
@@ -72,7 +72,7 @@ func NewClient(cfg options.OPNSenseConfig, userAgentVersion string, log *slog.Lo
 			"arp":                     "api/diagnostics/interface/search_arp",
 			"dhcpv4":                  "api/dhcpv4/leases/searchLease",
 			"openVPNInstances":        "api/openvpn/instances/search",
-			"gatewaysStatus":          "api/routes/gateway/status",
+			"gatewaysStatus":          "api/routing/settings/searchGateway",
 			"unboundDNSStatus":        "api/unbound/diagnostics/stats",
 			"cronJobs":                "api/cron/settings/searchJobs",
 			"wireguardClients":        "api/wireguard/service/show",

--- a/opnsense/utils.go
+++ b/opnsense/utils.go
@@ -65,3 +65,9 @@ func sliceIntToMapStringInt(strings []string, url EndpointPath) (map[string]int,
 
 	return ints, nil
 }
+
+// parseStringToBool parses a string value to a bool value.
+// The value is considered true if it is not "0".
+func parseStringToBool(value string) bool {
+	return value != "0"
+}

--- a/opnsense/utils_test.go
+++ b/opnsense/utils_test.go
@@ -80,3 +80,37 @@ func TestSliceIntToMapStringInt(t *testing.T) {
 		t.Errorf("Expected %v, got %v", expected, result)
 	}
 }
+
+func TestParseStringToBool(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected bool
+	}{
+		{
+			name:     "Zero",
+			value:    "0",
+			expected: false,
+		},
+		{
+			name:     "One",
+			value:    "1",
+			expected: true,
+		},
+		{
+			name:     "Invalid/Unknown",
+			value:    "2",
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := parseStringToBool(tc.value)
+			if result != tc.expected {
+				t.Errorf("parseStringToBool(%s) = %v; want %v",
+					tc.value, result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Pull Request Template

## Description

Collects more information from gateways.
The api `api/routes/gateway/status` only return some high level info from monitoring and interface status, the api `api/routing/settings/searchGateway` returns the entire gateway configuration and status.

Example of previous api response:
```json
{
  "items": [
    {
      "name": "Test",
      "address": "x.x.x.x",
      "status": "none",
      "loss": "0.0 %",
      "delay": "12.6 ms",
      "stddev": "0.2 ms",
      "monitor": "9.9.9.9",
      "status_translated": "Online"
    }
  ],
  "status": "ok"
}
```

Example of the new api response:
```json
{
  "total": 2,
  "rowCount": 2,
  "current": 1,
  "rows": [
    {
      "disabled": false,
      "name": "Test",
      "descr": "",
      "interface": "opt1",
      "ipprotocol": "inet",
      "gateway": "x.x.x.x",
      "defaultgw": true,
      "fargw": "0",
      "monitor_disable": "0",
      "monitor_noroute": "0",
      "monitor": "9.9.9.9",
      "force_down": "0",
      "priority": "1",
      "weight": "1",
      "latencylow": "",
      "current_latencylow": "200",
      "latencyhigh": "",
      "current_latencyhigh": "500",
      "losslow": "5",
      "current_losslow": "5",
      "losshigh": "10",
      "current_losshigh": "10",
      "interval": "1",
      "current_interval": "1",
      "time_period": "60",
      "current_time_period": "60",
      "loss_interval": "1",
      "current_loss_interval": "1",
      "data_length": "1",
      "current_data_length": "1",
      "uuid": "cd8d228f-c7ae-4748-be5c-414d847f0383",
      "if": "ix0",
      "attribute": 0,
      "dynamic": true,
      "virtual": false,
      "upstream": true,
      "interface_descr": "SFP1",
      "status": "Online",
      "delay": "12.7 ms",
      "stddev": "0.3 ms",
      "loss": "0.0 %",
      "label_class": "fa fa-plug text-success"
    },
    {
      "disabled": true,
      "name": "ETH_10G_0",
      "descr": "Ethernet connected to 10Gbps interface port 0",
      "interface": "opt4",
      "ipprotocol": "inet",
      "defaultgw": false,
      "fargw": "0",
      "monitor_disable": "0",
      "monitor_noroute": "0",
      "monitor": "",
      "force_down": "0",
      "priority": "255",
      "weight": "1",
      "latencylow": "",
      "current_latencylow": "200",
      "latencyhigh": "",
      "current_latencyhigh": "500",
      "losslow": "",
      "current_losslow": "10",
      "losshigh": "",
      "current_losshigh": "20",
      "interval": "",
      "current_interval": "1",
      "time_period": "",
      "current_time_period": "60",
      "loss_interval": "",
      "current_loss_interval": "4",
      "data_length": "",
      "current_data_length": "1",
      "uuid": "6b90f31c-5986-4b7f-b7cc-680592b073bf",
      "if": "vtnet1",
      "attribute": 2,
      "dynamic": true,
      "defunct": true,
      "virtual": false,
      "upstream": true,
      "interface_descr": "ETH_10G_0",
      "status": "Pending",
      "delay": "~",
      "stddev": "~",
      "loss": "~",
      "label_class": "fa fa-plug text-default"
    }
  ]
}
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Tested on my local OPNSense instance

## Checklist:

Please delete options that are not relevant.

- [x] I have updated the docs/metrics.md file, when I introduced new metrics
- [x] I have made corresponding changes to the documentation