### PR TITLE
feat: Add default_gateway label to status metric

### DIFF
--- a/internal/collector/gateways.go
+++ b/internal/collector/gateways.go
@@ -105,7 +105,7 @@ func (c *gatewaysCollector) Register(namespace, instanceLabel string, log *slog.
 	)
 	c.status = buildPrometheusDesc(c.subsystem, "status",
 		"Status of the gateway by name and address (0 = Offline, 1 = Online, 2 = Unknown, 3 = Pending)",
-		[]string{"name", "address"},
+		[]string{"name", "address", "default_gateway"},
 	)
 }
 
@@ -240,6 +240,7 @@ func (c *gatewaysCollector) Update(client *opnsense.Client, ch chan<- prometheus
 					float64(v.Status),
 					v.Name,
 					v.Monitor,
+					strconv.FormatBool(v.DefaultGateway),
 					c.instance,
 				)
 			}


### PR DESCRIPTION
# Pull Request Template

## Description

Add `default_gateway` boolean label to `opnsense_gateways_status` metric in order to be able to track which interface is being used as primary WAN

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

Please delete options that are not relevant.

- [x] I have updated the docs/metrics.md file, when I introduced new metrics


I did all the work #50 to be able to monitor this and ended up forgetting to expose it 🤦  my bad