### PR TITLE
Document Unbound extended statistics requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Finaly we have a Grafana dashboard to visualize the data from this exporter. The
 | GUI |  VPN: OpenVPN: Instances          |
 | GUI |  VPN: WireGuard                   |
 
+## OPNsense settings
+
+The exporter requires that the following OPNsense settings be enabled:
+* Unbound collector:
+  * Unbound DNS > Advanced > Extended Statistics
+
 ## Usage
 
 ### Docker


### PR DESCRIPTION
## Description

It looks like Unbound requires the "Extended Statistics" setting to be enabled for the Unbound collector to not error. This documents the requirement in the readme.

## Type of change

- [x] Just a documentation update

## How Has This Been Tested?

N/A

## Checklist:

Please delete options that are not relevant.

- [x] I have made corresponding changes to the documentation