### PR TITLE
Fix firmware metrics and optionally query for new updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ Gathering metrics for specific subsystems can be disabled with the following fla
 - `--exporter.disable-firewall` - Disable the scraping of Firewall (pf) metrics. Defaults to `false`.
 - `--exporter.disable-firmware` - Disable the scraping of Firmware infos. Defaults to `false`.
 
+Specific collectors can be configured with the following flags:
+- `--exporter.firmware-update-check-interval` - Set the minimum time interval between Firmware update checks. Set to 0 to disable. If enabled, the minimum recommended value is `1h`. Defaults to `0s`.
+
 To disable the exporter metrics itself use the following flag:
 
 - `--web.disable-exporter-metrics` - Exclude metrics about the exporter itself (promhttp_*, process_*, go_*). Defaults to `false`.
@@ -202,6 +205,8 @@ Flags:
                                  Disable the scraping of the firewall (pf) metrics ($OPNSENSE_EXPORTER_DISABLE_FIREWALL)
       --[no-]exporter.disable-firmware
                                  Disable the scraping of the firmware metrics ($OPNSENSE_EXPORTER_DISABLE_FIRMWARE)
+      --exporter.firmware-update-check-interval=0s  
+                                 Minimum interval between firmware update checks. Set to 0 to disable the check. ($OPNSENSE_EXPORTER_FIRMWARE_UPDATE_CHECK_INTERVAL)
       --web.telemetry-path="/metrics"
                                  Path under which to expose metrics.
       --[no-]web.disable-exporter-metrics

--- a/internal/options/collectors.go
+++ b/internal/options/collectors.go
@@ -1,6 +1,10 @@
 package options
 
-import "github.com/alecthomas/kingpin/v2"
+import (
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+)
 
 var (
 	arpTableCollectorDisabled = kingpin.Flag(
@@ -31,28 +35,34 @@ var (
 		"exporter.disable-firmware",
 		"Disable the scraping of the firmware metrics",
 	).Envar("OPNSENSE_EXPORTER_DISABLE_FIRMWARE").Default("false").Bool()
+	firmwareCollectorUpdateCheckInterval = kingpin.Flag(
+		"exporter.firmware-update-check-interval",
+		"Minimum interval between firmware update checks. Set to 0 to disable the check.",
+	).Envar("OPNSENSE_EXPORTER_FIRMWARE_UPDATE_CHECK_INTERVAL").Default("0s").Duration()
 )
 
-// CollectorsDisableSwitch hold the enabled/disabled state of the collectors
-type CollectorsDisableSwitch struct {
-	ARP       bool
-	Cron      bool
-	Wireguard bool
-	Unbound   bool
-	OpenVPN   bool
-	Firewall  bool
-	Firmware  bool
+// CollectorsConfig hold the enabled/disabled state of the collectors
+type CollectorsConfig struct {
+	ARP                   bool
+	Cron                  bool
+	Wireguard             bool
+	Unbound               bool
+	OpenVPN               bool
+	Firewall              bool
+	Firmware              bool
+	FirmwareCheckInterval time.Duration
 }
 
-// CollectorsSwitches returns configured instances of CollectorsDisableSwitch
-func CollectorsSwitches() CollectorsDisableSwitch {
-	return CollectorsDisableSwitch{
-		ARP:       !*arpTableCollectorDisabled,
-		Cron:      !*cronTableCollectorDisabled,
-		Wireguard: !*wireguardCollectorDisabled,
-		Unbound:   !*unboundCollectorDisabled,
-		OpenVPN:   !*openVPNCollectorDisabled,
-		Firewall:  !*firewallCollectorDisabled,
-		Firmware:  !*firmwareCollectorDisabled,
+// GetCollectorsConfig returns configured instances of CollectorsDisableSwitch
+func GetCollectorsConfig() CollectorsConfig {
+	return CollectorsConfig{
+		ARP:                   !*arpTableCollectorDisabled,
+		Cron:                  !*cronTableCollectorDisabled,
+		Wireguard:             !*wireguardCollectorDisabled,
+		Unbound:               !*unboundCollectorDisabled,
+		OpenVPN:               !*openVPNCollectorDisabled,
+		Firewall:              !*firewallCollectorDisabled,
+		Firmware:              !*firmwareCollectorDisabled,
+		FirmwareCheckInterval: *firmwareCollectorUpdateCheckInterval,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -56,34 +56,36 @@ func main() {
 		registry.MustRegister(promcollectors.NewGoCollector())
 	}
 
-	collectorsSwitches := options.CollectorsSwitches()
+	collectorsConfig := options.GetCollectorsConfig()
 	collectorOptionFuncs := []collector.Option{}
 
-	if !collectorsSwitches.Unbound {
+	if !collectorsConfig.Unbound {
 		collectorOptionFuncs = append(collectorOptionFuncs, collector.WithoutUnboundCollector())
 		logger.Info("unbound collector disabled")
 	}
-	if !collectorsSwitches.Wireguard {
+	if !collectorsConfig.Wireguard {
 		collectorOptionFuncs = append(collectorOptionFuncs, collector.WithoutWireguardCollector())
 		logger.Info("wireguard collector disabled")
 	}
-	if !collectorsSwitches.Cron {
+	if !collectorsConfig.Cron {
 		collectorOptionFuncs = append(collectorOptionFuncs, collector.WithoutCronCollector())
 		logger.Info("cron collector disabled")
 	}
-	if !collectorsSwitches.ARP {
+	if !collectorsConfig.ARP {
 		collectorOptionFuncs = append(collectorOptionFuncs, collector.WithoutArpTableCollector())
 		logger.Info("arp collector disabled")
 	}
-	if !collectorsSwitches.Firewall {
+	if !collectorsConfig.Firewall {
 		collectorOptionFuncs = append(collectorOptionFuncs, collector.WithoutFirewallCollector())
 		logger.Info("firewall collector disabled")
 	}
-	if !collectorsSwitches.Firmware {
+	if !collectorsConfig.Firmware {
 		collectorOptionFuncs = append(collectorOptionFuncs, collector.WithoutFirmwareCollector())
 		logger.Info("firmware collector disabled")
+	} else {
+		collectorOptionFuncs = append(collectorOptionFuncs, collector.FirmwareCollectorUpdateCheckInterval(collectorsConfig.FirmwareCheckInterval))
 	}
-	if !collectorsSwitches.OpenVPN {
+	if !collectorsConfig.OpenVPN {
 		collectorOptionFuncs = append(collectorOptionFuncs, collector.WithoutOpenVPNCollector())
 		logger.Info("openvpn collector disabled")
 	}


### PR DESCRIPTION
# Pull Request Template

## Description

[Firmware updates are currently broken](https://github.com/AthennaMind/opnsense-exporter/issues/47), because they assume that a couple of fields will always be set. These fields are unset when a check for firmware updates has not ran since the last reboot. This PR does two things: it doesn't parse these fields when a firmware check has not been ran, and it periodically asks OPNsense to check for firmware updates.

The update check is disabled by default. When enabled, it will periodically request that OPNsense checks for updates. This is a long-running operation, so it is done asynchronously. Checks are in place to ensure that it does not run too frequently, and that only one update request is ran at a time. Users can configure the update check interval. When the firmware collector is disabled, so are update checks.

Fixes #47

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] Ran unit tests (`go test ./...`)
- [x] Rebooted OPNsense instance (clearing update status) and queried the exporter (triggering an update check).
- [x] Queried the exporter multiple times in a row.
- [x] Queried the exporter multiple times in quick succession.
- [x] Checked for race conditions with `go build -race .`.
- [x] Queried the exporter with env var set instead of the new CLI flag for interval.
- [x] Queried the exporter without the CLI flag or env var set (update check disabled).

## Checklist:

Please delete options that are not relevant.

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works - this would rely heavily on mocking opnsense which this project does not have a framework for. Areas modified do not have existing tests.
- [x] New and existing unit tests pass locally with my changes