### PR TITLE
fix: enforce correct data types for gateway metrics (weight, monitor_disable and priority)

### DIFF
--- a/internal/collector/gateways.go
+++ b/internal/collector/gateways.go
@@ -139,7 +139,7 @@ func (c *gatewaysCollector) Update(client *opnsense.Client, ch chan<- prometheus
 			v.Interface,
 			v.IPProtocol,
 			strconv.FormatBool(v.Enabled),
-			v.Weight,
+			strconv.Itoa(v.Weight),
 			v.HardwareInterface,
 			strconv.FormatBool(v.Upstream),
 			c.instance,

--- a/opnsense/gateways.go
+++ b/opnsense/gateways.go
@@ -28,7 +28,7 @@ type gatewayConfigurationResponse struct {
 		Gateway              string `json:"gateway"`
 		DefaultGateway       bool   `json:"defaultgw"`
 		FarGateway           string `json:"fargw"`
-		MonitorDisable       string `json:"monitor_disable"`
+		MonitorDisable       bool   `json:"monitor_disable"`
 		MonitorNoRoute       string `json:"monitor_noroute"`
 		Monitor              string `json:"monitor"`
 		ForceDown            string `json:"force_down"`
@@ -144,7 +144,7 @@ func (c *Client) FetchGateways() (Gateways, *APICallError) {
 		delay := -1.0
 		stdDev := -1.0
 		loss := -1.0
-		if !v.Disabled && !parseStringToBool(v.MonitorDisable) {
+		if !v.Disabled && !v.MonitorDisable {
 			delay = parseStringToFloatWithReplace(v.Delay, c.gatewayRTTRegex, " ms", "rtt", c.log)
 			stdDev = parseStringToFloatWithReplace(v.StdDev, c.gatewayRTTRegex, " ms", "rttd", c.log)
 			loss = parseStringToFloatWithReplace(v.Loss, c.gatewayLossRegex, " %", "loss", c.log)
@@ -159,7 +159,7 @@ func (c *Client) FetchGateways() (Gateways, *APICallError) {
 			Gateway:              v.Gateway,
 			DefaultGateway:       v.DefaultGateway,
 			FarGateway:           v.FarGateway,
-			MonitorEnabled:       !parseStringToBool(v.MonitorDisable),
+			MonitorEnabled:       !v.MonitorDisable,
 			MonitorNoRoute:       parseStringToBool(v.MonitorNoRoute),
 			Monitor:              v.Monitor,
 			ForceDown:            parseStringToBool(v.ForceDown),

--- a/opnsense/gateways.go
+++ b/opnsense/gateways.go
@@ -32,7 +32,7 @@ type gatewayConfigurationResponse struct {
 		MonitorNoRoute       string `json:"monitor_noroute"`
 		Monitor              string `json:"monitor"`
 		ForceDown            string `json:"force_down"`
-		Priority             string `json:"priority"`
+		Priority             int    `json:"priority"`
 		Weight               int    `json:"weight"`
 		LatencyLow           string `json:"latencylow"`
 		CurrentLatencyLow    string `json:"current_latencylow"`
@@ -78,7 +78,7 @@ type Gateway struct {
 	MonitorNoRoute       bool
 	Monitor              string
 	ForceDown            bool
-	Priority             string
+	Priority             int
 	Weight               int
 	LatencyLow           string
 	LatencyHigh          string

--- a/opnsense/gateways.go
+++ b/opnsense/gateways.go
@@ -33,7 +33,7 @@ type gatewayConfigurationResponse struct {
 		Monitor              string `json:"monitor"`
 		ForceDown            string `json:"force_down"`
 		Priority             string `json:"priority"`
-		Weight               string `json:"weight"`
+		Weight               int `json:"weight"`
 		LatencyLow           string `json:"latencylow"`
 		CurrentLatencyLow    string `json:"current_latencylow"`
 		LatencyHigh          string `json:"latencyhigh"`

--- a/opnsense/gateways.go
+++ b/opnsense/gateways.go
@@ -33,7 +33,7 @@ type gatewayConfigurationResponse struct {
 		Monitor              string `json:"monitor"`
 		ForceDown            string `json:"force_down"`
 		Priority             string `json:"priority"`
-		Weight               int `json:"weight"`
+		Weight               int    `json:"weight"`
 		LatencyLow           string `json:"latencylow"`
 		CurrentLatencyLow    string `json:"current_latencylow"`
 		LatencyHigh          string `json:"latencyhigh"`
@@ -79,7 +79,7 @@ type Gateway struct {
 	Monitor              string
 	ForceDown            bool
 	Priority             string
-	Weight               string
+	Weight               int
 	LatencyLow           string
 	LatencyHigh          string
 	LossLow              string


### PR DESCRIPTION
## Description

Fixes an issue with the app expecting the weight,priority and monitor_disabled fields to be strings, which opnsense returns as int for weight and priority and a boolean for the monitor_disabled.
```
time=2025-04-18T16:38:19.509Z level=ERROR source=collector.go:232 msg="failed to update" component=collector collector_name=gateways err="opnsense-client api call error: endpoint: api/routing/settings/searchGateway; failed status code: 200; msg: failed to unmarshal response body: json: cannot unmarshal number into Go struct field .rows.weight of type string"
```
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested the response of my opnsense router against the gateway settings endpoint. You can see that the weight and priority fields are returned as int value and monitor_disable is a boolean.
```
curl -k \
  -X POST \
  -H "Content-Type: application/json" \
  -u "ommited:ommited" \
  -d '{}' \
  https://example.com/api/routing/settings/searchGateway
{"total":1,"rowCount":1,"current":1,"rows":[{"interface":"wan","weight":1,"ipprotocol":"inet","name":"WAN_DHCP","descr":"Interface WAN_DHCP Gateway","monitor_disable":true,"gateway_interface":false,"if":"igc0","dynamic":true,      "virtual":true,"priority":254,"gateway":"<ommited>","uuid":"WAN_DHCP","disabled":false,"upstream":false,"defaultgw":true,"interface_descr":"WAN","status":"Online","delay":"~","stddev":"~","loss":"~","label_class":"fa fa-plu
```