### PR TITLE
fix: System status API changes in OPNsense>=25.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ secret
 local.docker-compose.yml
 *.DS_Store
 
+# IDEs
+.idea/

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -193,7 +193,8 @@ func (c *Collector) collectHealthMetrics(ch chan<- prometheus.Metric) error {
 		return err
 	}
 
-	if systemStatus.System.Status != opnsense.HealthCheckStatusOK {
+	if systemStatus.System.Status != opnsense.HealthCheckStatusOK &&
+		systemStatus.Metadata.System.Status != opnsense.HealthCheckStatusOK_v25_1 {
 		c.isUp.Set(0)
 		c.isUp.Collect(ch)
 		return nil
@@ -202,7 +203,8 @@ func (c *Collector) collectHealthMetrics(ch chan<- prometheus.Metric) error {
 	c.isUp.Set(1)
 	c.firewallHealthStatus.Set(1)
 
-	if systemStatus.Firewall.Status != opnsense.HealthCheckStatusOK {
+	if systemStatus.Firewall.Status != opnsense.HealthCheckStatusOK &&
+		systemStatus.Metadata.Firewall.Status != opnsense.HealthCheckStatusOK_v25_1 {
 		c.firewallHealthStatus.Set(0)
 	}
 

--- a/opnsense/health_check.go
+++ b/opnsense/health_check.go
@@ -14,9 +14,31 @@ type HealthCheckResponse struct {
 		Status     string `json:"status"`
 		StatusCode int    `json:"statusCode"`
 	} `json:"Firewall"`
+	// OPNsense>25.1 has a different structure
+	// See https://github.com/AthennaMind/opnsense-exporter/issues/48#issuecomment-2692494735
+	Metadata struct {
+		System struct {
+			Status int `json:"status"`
+		} `json:"System"`
+		CrashReporter struct {
+			Message    string `json:"message"`
+			Status     string `json:"status"`
+			StatusCode int    `json:"statusCode"`
+		} `json:"CrashReporter"`
+		Firewall struct {
+			Message    string `json:"message"`
+			Status     int    `json:"status"`
+			StatusCode int    `json:"statusCode"`
+		} `json:"Firewall"`
+	} `json:"metadata"`
 }
 
-const HealthCheckStatusOK = "OK"
+const (
+	HealthCheckStatusOK = "OK"
+	// OPNsense>25.1 has a different value
+	// See https://github.com/AthennaMind/opnsense-exporter/issues/48#issuecomment-2692494735
+	HealthCheckStatusOK_v25_1 = 2
+)
 
 // HealthCheck checks if the OPNsense is up and running.
 func (c *Client) HealthCheck() (HealthCheckResponse, error) {


### PR DESCRIPTION
## Description

OPNsense 25.1+ has a backwards incompatible API for the system status endpoint.

Fixes https://github.com/AthennaMind/opnsense-exporter/issues/48

## Type of change

This adds support for the new structure without breaking compatibility.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Published the fix to `ghcr.io/dcelasun/opnsense-exporter:latest` and tested against an OPNsense 25.1.7 instance. CI [passed](https://github.com/dcelasun/opnsense-exporter/actions/runs/15257427149) as well.

Grafana before and after fix:
![image](https://github.com/user-attachments/assets/d490ef57-7d42-4dc9-8aff-669353d43f36)


## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes