### PR TITLE
the OPS_ADDITIONAL_ARGS needed be conditial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ local-run:
 	./${BINARY_NAME} --log.level="debug" \
 		--log.format="logfmt" \
 		--web.telemetry-path="/metrics" \
-		--web.listen-address=":$( or $(OPS_EXPORTER_PORT), 8080)" \
+		--web.listen-address=":$(or $(OPS_EXPORTER_PORT), 8080)" \
 		--runtime.gomaxprocs=4 \
 		--exporter.instance-label="$(or $(OPS_INSTANCE), opnsense-local1)" \
 		--opnsense.protocol="https" \
@@ -24,8 +24,8 @@ local-run:
 		--opnsense.api-key="${OPS_API_KEY}" \
 		--opnsense.api-secret="${OPS_API_SECRET}" \
 		--web.disable-exporter-metrics \
-		"${OPS_ADDITIONAL_ARGS}"
-		
+		$(if $(OPS_ADDITIONAL_ARGS),"${OPS_ADDITIONAL_ARGS}")
+
 test:
 	go test ./...
 


### PR DESCRIPTION
If not and OPS_ADDITIONAL_ARGS not set, there will be dangling "". 

I introduced this in 111b1dc and broke the behaviour without OPS_ADDITIONAL_ARGS

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Running the makefile with and without the variable being set.
