### PR TITLE
Rework data representation

### DIFF
--- a/internal/collector/firmware.go
+++ b/internal/collector/firmware.go
@@ -93,7 +93,7 @@ func (c *firmwareCollector) Update(client *opnsense.Client, ch chan<- prometheus
 		return err
 	}
 
-	ch <- prometheus.MustNewConstMetric(c.needsReboot, prometheus.GaugeValue, float64(data.NeedsReboot), strconv.Itoa(data.NeedsReboot), c.instance)
+	ch <- prometheus.MustNewConstMetric(c.needsReboot, prometheus.GaugeValue, float64(1), data.NeedsReboot, c.instance)
 	ch <- prometheus.MustNewConstMetric(c.newPackages, prometheus.GaugeValue, float64(data.NewPackages), strconv.Itoa(data.NewPackages), c.instance)
 	ch <- prometheus.MustNewConstMetric(c.lastCheck, prometheus.GaugeValue, float64(1), data.LastCheck, c.instance)
 	ch <- prometheus.MustNewConstMetric(c.osVersion, prometheus.GaugeValue, float64(1), data.OsVersion, c.instance)
@@ -101,7 +101,7 @@ func (c *firmwareCollector) Update(client *opnsense.Client, ch chan<- prometheus
 	ch <- prometheus.MustNewConstMetric(c.productId, prometheus.GaugeValue, float64(1), data.ProductId, c.instance)
 	ch <- prometheus.MustNewConstMetric(c.productVersion, prometheus.GaugeValue, float64(1), data.ProductVersion, c.instance)
 	ch <- prometheus.MustNewConstMetric(c.upgradePackages, prometheus.GaugeValue, float64(data.UpgradePackages), strconv.Itoa(data.UpgradePackages), c.instance)
-	ch <- prometheus.MustNewConstMetric(c.upgradeNeedsReboot, prometheus.GaugeValue, float64(data.UpgradeNeedsReboot), strconv.Itoa(data.UpgradeNeedsReboot), c.instance)
+	ch <- prometheus.MustNewConstMetric(c.upgradeNeedsReboot, prometheus.GaugeValue, float64(1), data.UpgradeNeedsReboot, c.instance)
 
 	return nil
 }


### PR DESCRIPTION
# Description

This makes sure that if the OPNsense device has not checked for updates yet, the exporter will return "undefined" instead of wrong data. This also addresses the issue AthennaMind#65 with a failed string to int conversion.

Fixes # (issue)

#65 

## Type of change

Please delete options that are not relevant.

[x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

By running two instances of the exporter against two different OPNSense instances: one that never ran through the update process and one that fetched updates.