### PR TITLE
fix: use int64 to prevent type change across architectures (Fixes #80)

### DIFF
--- a/opnsense/interfaces.go
+++ b/opnsense/interfaces.go
@@ -45,16 +45,16 @@ type Interface struct {
 	Name                  string
 	Device                string
 	Type                  string
-	MTU                   int
-	PacketsReceived       int
-	PacketsTransmitted    int
-	BytesReceived         int
-	BytesTransmitted      int
-	MulticastsReceived    int
-	MulticastsTransmitted int
-	InputErrors           int
-	OutputErrors          int
-	Collisions            int
+	MTU                   int64
+	PacketsReceived       int64
+	PacketsTransmitted    int64
+	BytesReceived         int64
+	BytesTransmitted      int64
+	MulticastsReceived    int64
+	MulticastsTransmitted int64
+	InputErrors           int64
+	OutputErrors          int64
+	Collisions            int64
 }
 
 type Interfaces struct {

--- a/opnsense/openvpn.go
+++ b/opnsense/openvpn.go
@@ -12,9 +12,9 @@ type openVPNSearchResponse struct {
 		DevType     string `json:"dev_type"`
 		Enabled     string `json:"enabled"`
 	} `json:"rows"`
-	RowCount int `json:"rowCount"`
-	Total    int `json:"total"`
-	Current  int `json:"current"`
+	RowCount int64 `json:"rowCount"`
+	Total    int64 `json:"total"`
+	Current  int64 `json:"current"`
 }
 
 type openVPNSearchSessionsResponse struct {
@@ -24,9 +24,9 @@ type openVPNSearchSessionsResponse struct {
 		VirtualAddress string `json:"virtual_address"`
 		Status         string `json:"status"`
 	} `json:"rows"`
-	RowCount int `json:"rowCount"`
-	Total    int `json:"total"`
-	Current  int `json:"current"`
+	RowCount int64 `json:"rowCount"`
+	Total    int64 `json:"total"`
+	Current  int64 `json:"current"`
 }
 
 type OpenVPN struct {
@@ -34,7 +34,7 @@ type OpenVPN struct {
 	Description string
 	Role        string
 	DevType     string
-	Enabled     int
+	Enabled     int64
 }
 type OpenVPNInstances struct {
 	Rows []OpenVPN

--- a/opnsense/system.go
+++ b/opnsense/system.go
@@ -92,7 +92,7 @@ type Temperature struct {
 	Device                string
 	DeviceSeq             string
 	Type                  string
-	TemperatureCelsuis    int
+	TemperatureCelsuis    int64
 	TemperatureFahrenheit float32
 }
 

--- a/opnsense/unbound_dns.go
+++ b/opnsense/unbound_dns.go
@@ -192,12 +192,12 @@ type unboundDNSStatusResponse struct {
 type UnboundDNSOverview struct {
 	AnswerRcodes      map[string]int
 	QueryTypes        map[string]int
-	Total             int
-	BlocklistSize     int
-	Passed            int
-	AnswerRcodesTotal int
-	AnnswerBogusTotal int
-	AnswerSecureTotal int
+	Total             int64
+	BlocklistSize     int64
+	Passed            int64
+	AnswerRcodesTotal int64
+	AnnswerBogusTotal int64
+	AnswerSecureTotal int64
 	UptimeSeconds     float64
 }
 

--- a/opnsense/utils.go
+++ b/opnsense/utils.go
@@ -11,8 +11,8 @@ import (
 // parseStringToInt parses a string value to an int value.
 // The endpoint is used to identify the EndpointPath that the caller used.
 // so we can propagate in the *APICallError.
-func parseStringToInt(value string, endpoint EndpointPath) (int, *APICallError) {
-	intValue, err := strconv.Atoi(value)
+func parseStringToInt(value string, endpoint EndpointPath) (int64, *APICallError) {
+	intValue, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
 		return 0, &APICallError{
 			Endpoint:   string(endpoint),
@@ -52,8 +52,8 @@ func parseStringToFloatWithReplace(value string, regex *regexp.Regexp, replacePa
 // The endpoint is used to identify the EndpointPath that the caller used.
 // so we can propagate in the *APICallError.
 // Fails if any of the string values in the slice cannot be parsed to an int.
-func sliceIntToMapStringInt(strings []string, url EndpointPath) (map[string]int, *APICallError) {
-	ints := make(map[string]int)
+func sliceIntToMapStringInt(strings []string, url EndpointPath) (map[string]int64, *APICallError) {
+	ints := make(map[string]int64)
 
 	for _, str := range strings {
 		value, err := parseStringToInt(str, url)

--- a/opnsense/utils_test.go
+++ b/opnsense/utils_test.go
@@ -72,7 +72,7 @@ func TestParsePercentage(t *testing.T) {
 
 func TestSliceIntToMapStringInt(t *testing.T) {
 	input := []string{"1", "2", "3"}
-	expected := map[string]int{"1": 1, "2": 2, "3": 3}
+	expected := map[string]int64{"1": 1, "2": 2, "3": 3}
 
 	result, _ := sliceIntToMapStringInt(input, "test")
 


### PR DESCRIPTION
## Description

Previously, the code relied on the default int type, which can vary between 32-bit and 64-bit systems. This caused inconsistent behavior and potential overflow issues. Using int64 ensures consistent behavior across platforms.

Fixes #80 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] make local-run
- [x] make test

## Checklist:

- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules