### PR TITLE
Add peer-status to wireguard peer metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -124,6 +124,7 @@ opnsense_unbound_dns_uptime_seconds | Gauge | n/a | Unbound | Uptime of the unbo
 | Metric Name | Type | Labels | Subsystem | Description | Disable Flag |
 | --- | --- | --- | --- | --- | --- |
 opnsense_wireguard_interfaces_status | Gauge | name, description, public_key | Wireguard | Wireguard interfaces status by name, description and public key (1 = up, 0 = down) | --exporter.disable-wireguard  |
+| opnsense_wireguard_peer_status | Gauge | device, device_type, device_name, peer_name | Wireguard | Wireguard peer status (1 = up, 0 = down, 2 = unknown) | --exporter.disable-wireguard  |
 opnsense_wireguard_peer_received_bytes_total | Counter | device, device_type, device_name, peer_name | Wireguard | Bytes received by this wireguard peer | --exporter.disable-wireguard  |
 opnsense_wireguard_peer_transmitted_bytes_total | Counter | device, device_type, device_name, peer_name | Wireguard | Bytes transmitted by this wireguard peer | --exporter.disable-wireguard  |
 opnsense_wireguard_peer_last_handshake_seconds | Gauge | device, device_type, device_name, peer_name | Wireguard | Last handshake time in seconds by this wireguard peer | --exporter.disable-wireguard  |


### PR DESCRIPTION

## Description

This change adds the peer-status as opnsense_wireguard_peer_status. This will allow alerting based on peer status and a way of alerting when the interface is up but the peer is offline.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

Please delete options that are not relevant.

- [x] I have updated the docs/metrics.md file, when I introduced new metrics
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
