### PR TITLE
add the real address to the metrics

### DIFF
--- a/internal/collector/openvpn.go
+++ b/internal/collector/openvpn.go
@@ -38,7 +38,7 @@ func (c *openVPNCollector) Register(namespace, instanceLabel string, log *slog.L
 	)
 	c.sessions = buildPrometheusDesc(c.subsystem, "sessions",
 		"OpenVPN session (1 = ok, 0 = not ok)",
-		[]string{"description", "virtual_address", "username"},
+		[]string{"description", "real_address", "virtual_address", "username"},
 	)
 }
 
@@ -75,6 +75,7 @@ func (c *openVPNCollector) Update(client *opnsense.Client, ch chan<- prometheus.
 			prometheus.GaugeValue,
 			float64(session.Status),
 			session.Description,
+			session.RealAddress,
 			session.VirtualAddress,
 			session.Username,
 			c.instance,

--- a/opnsense/openvpn.go
+++ b/opnsense/openvpn.go
@@ -21,6 +21,7 @@ type openVPNSearchSessionsResponse struct {
 	Rows []struct {
 		Description    string `json:"description"`
 		Username       string `json:"username"`
+		RealAddress    string `json:"real_address"`
 		VirtualAddress string `json:"virtual_address"`
 		Status         string `json:"status"`
 	} `json:"rows"`
@@ -43,6 +44,7 @@ type OpenVPNInstances struct {
 type Sessions struct {
 	Description    string
 	Username       string
+	RealAddress    string
 	VirtualAddress string
 	Status         int
 }
@@ -105,6 +107,7 @@ func (c *Client) FetchOpenVPNSessions() (OpenVPNSessions, *APICallError) {
 		data.Rows = append(data.Rows, Sessions{
 			Description:    v.Description,
 			Username:       v.Username,
+			RealAddress:    v.RealAddress,
 			VirtualAddress: v.VirtualAddress,
 			Status:         parseOpenVPNsessionStatusToInt(v.Status),
 		})


### PR DESCRIPTION
If we have stale sessions with static addresses within the OpenVPN network we will get duplicate metrics errors

Stale sessions happen if the server does not have an aggressive keep alive configured and clients suspend and wake-up.
The error then raised is:

```
collected metric "opnsense_openvpn_sessions" { label:{name:"description" value:"$vpn-description"} label:{name:"opnsense_instance" value:"$instance-name"} label:{name:"username" value:"$username"} label:{name:"virtual_address" value:"$virtual-address"} gauge:{value:1}} was collected before with the same name and label values
```

(the $ parts of course replaced with the real contents)

This can be avoided if the real address of the vpn users (with their source port) is included.

Why is the original behavior problematic: The exporter errors out and as such the vpn is marked as down :)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Just a documentation update

## How Has This Been Tested?

I've been seeing the duplicate metrics error with a client of mine and have been running a version of the exporter with this change and without. The one without still errors out, the one with the chance works fine.
