### PR TITLE
actually use LastCheck instead of the status field

### DIFF
--- a/opnsense/firmware.go
+++ b/opnsense/firmware.go
@@ -81,7 +81,7 @@ func (c *Client) FetchFirmwareStatus() (FirmwareStatus, *APICallError) {
 		return data, err
 	}
 
-	if resp.Status != "none" {
+	if resp.LastCheck != "" {
 		data.OsVersion = resp.OsVersion
 		data.ProductABI = resp.ProductAbi
 		data.ProductId = resp.ProductID


### PR DESCRIPTION
The status field is not changed (this used to be different). Instead use LastCheck, which is only present IF the update check was run.

Fixes #100 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

