### PR TITLE
fix(gateways): parse Packetloss, Latency, and forced offline statuses

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -86,7 +86,7 @@ opnsense_protocol_arp_received_requests_total | Counter | n/a | Protocol Statist
 | --- | --- | --- | --- | --- | --- |
 opnsense_gateways_info | Gauge | name, description, device, protocol, enabled, weight, interface, upstream | Gateways | Configuration details of the gateway | n/a |
 opnsense_gateways_monitor_info | Gauge | name, enabled, no_route, address | Gateways | Configuration details of the gateway monitoring | n/a |
-opnsense_gateways_status | Gauge | address, name | Gateways | Status of the gateway by name and address (1 = up, 0 = down, 2 = unknown, 3 = pending) | n/a |
+opnsense_gateways_status | Gauge | address, name | Gateways | Status of the gateway by name and address (0 = offline, 1 = online, 2 = unknown, 3 = pending, 4 = packetloss, 5 = latency, 6 = offline forced) | n/a |
 opnsense_gateways_loss_percentage | Gauge | address, name | Gateways | The current gateway loss percentage by name and address | n/a |
 opnsense_gateways_rtt_milliseconds | Gauge | address, name | Gateways | RTT is the average (mean) of the round trip time in milliseconds by name and address | n/a |
 opnsense_gateways_rttd_milliseconds | Gauge | address, name | Gateways | RTTd is the standard deviation of the round trip time in milliseconds by name and address | n/a |

--- a/internal/collector/gateways.go
+++ b/internal/collector/gateways.go
@@ -104,7 +104,7 @@ func (c *gatewaysCollector) Register(namespace, instanceLabel string, log *slog.
 		[]string{"name", "address"},
 	)
 	c.status = buildPrometheusDesc(c.subsystem, "status",
-		"Status of the gateway by name and address (0 = Offline, 1 = Online, 2 = Unknown, 3 = Pending)",
+		"Status of the gateway by name and address (0 = Offline, 1 = Online, 2 = Unknown, 3 = Pending, 4 = Packetloss, 5 = Latency, 6 = Offline forced)",
 		[]string{"name", "address", "default_gateway"},
 	)
 }

--- a/opnsense/gateways.go
+++ b/opnsense/gateways.go
@@ -3,6 +3,7 @@ package opnsense
 import (
 	"log/slog"
 	"strconv"
+	"strings"
 )
 
 // GatewayStatus is the custom type that represents the status of a gateway
@@ -13,6 +14,9 @@ const (
 	GatewayStatusOnline
 	GatewayStatusUnknown
 	GatewayStatusPeding
+	GatewayStatusLoss
+	GatewayStatusLatency
+	GatewayStatusForcedDown
 )
 
 // gatewayConfigurationResponse is the response from the OPNsense API that contains the gateways configuration details
@@ -122,18 +126,48 @@ func convertPriorityToString(priority interface{}) string {
 }
 
 // parseGatewayStatus parses a string status to a GatewayStatus type.
+// OPNsense may report combined statuses such as "Latency, Packetloss";
+// the worst component wins (Offline > ForcedDown > Loss > Latency > Pending > Online).
 func parseGatewayStatus(statusTranslated string, logger *slog.Logger, originalStatus string) GatewayStatusType {
-	switch statusTranslated {
-	case "Online":
-		return GatewayStatusOnline
-	case "Offline":
-		return GatewayStatusOffline
-	case "Pending":
-		return GatewayStatusPeding
-	default:
+	worst := GatewayStatusType(-1)
+	worstRank := -1
+	rank := map[GatewayStatusType]int{
+		GatewayStatusOnline:     0,
+		GatewayStatusPeding:     1,
+		GatewayStatusLatency:    2,
+		GatewayStatusLoss:       3,
+		GatewayStatusForcedDown: 4,
+		GatewayStatusOffline:    5,
+	}
+	for _, part := range strings.Split(statusTranslated, ",") {
+		var s GatewayStatusType
+		switch strings.TrimSpace(part) {
+		case "Online":
+			s = GatewayStatusOnline
+		case "Offline":
+			s = GatewayStatusOffline
+		case "Pending":
+			s = GatewayStatusPeding
+		case "Packetloss":
+			s = GatewayStatusLoss
+		case "Latency":
+			s = GatewayStatusLatency
+		case "Offline (forced)":
+			s = GatewayStatusForcedDown
+		default:
+			logger.Warn("unknown gateway status detected", "status", originalStatus)
+			return GatewayStatusUnknown
+		}
+		if r := rank[s]; r > worstRank {
+			worstRank = r
+			worst = s
+		}
+	}
+	if worstRank < 0 {
 		logger.Warn("unknown gateway status detected", "status", originalStatus)
 		return GatewayStatusUnknown
 	}
+	return worst
 }
 
 // FetchGateways fetches the gateways status details from the OPNsense API

--- a/opnsense/gateways_test.go
+++ b/opnsense/gateways_test.go
@@ -1,0 +1,35 @@
+package opnsense
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/promslog"
+)
+
+func TestParseGatewayStatus(t *testing.T) {
+	logger := promslog.NewNopLogger()
+	tests := []struct {
+		name string
+		in   string
+		want GatewayStatusType
+	}{
+		{"online", "Online", GatewayStatusOnline},
+		{"offline", "Offline", GatewayStatusOffline},
+		{"pending", "Pending", GatewayStatusPeding},
+		{"packetloss", "Packetloss", GatewayStatusLoss},
+		{"latency", "Latency", GatewayStatusLatency},
+		{"forced", "Offline (forced)", GatewayStatusForcedDown},
+		{"combined latency packetloss", "Latency, Packetloss", GatewayStatusLoss},
+		{"combined online latency", "Online, Latency", GatewayStatusLatency},
+		{"unknown", "Mystery", GatewayStatusUnknown},
+		{"empty", "", GatewayStatusUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseGatewayStatus(tt.in, logger, tt.in)
+			if got != tt.want {
+				t.Errorf("parseGatewayStatus(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

`parseGatewayStatus` only recognised `Online`, `Offline`, and `Pending`, so OPNsense's other reported states (`Packetloss`, `Latency`, `Offline (forced)`) and combined states like `Latency, Packetloss` collapsed to `Unknown` and logged a warning on every scrape. Added the missing constants, a comma-aware parser that picks the worst component, and updated the metric description in `docs/metrics.md`.

Fixes #102

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] `go test ./...` (added `opnsense/gateways_test.go` covering each singular status, two combined statuses, an unknown string, and an empty string)
- [x] `go build ./...`

## Checklist:

- [x] I have updated the docs/metrics.md file, when I introduced new metrics
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes