### PR TITLE
feat(unbound): expose DNSSEC answer_bogus/secure metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -118,6 +118,8 @@ opnsense_protocol_icmp_dropped_by_reason_total | CounterVector | reason | Protoc
 | Metric Name | Type | Labels | Subsystem | Description | Disable Flag |
 | --- | --- | --- | --- | --- | --- |
 opnsense_unbound_dns_uptime_seconds | Gauge | n/a | Unbound | Uptime of the unbound DNS service in seconds | --exporter.disable-unbound |
+opnsense_unbound_dns_answer_bogus_total | Counter | n/a | Unbound | Total number of responses that failed DNSSEC validation | --exporter.disable-unbound |
+opnsense_unbound_dns_answer_secure_total | Counter | n/a | Unbound | Total number of responses that successfully passed DNSSEC validation | --exporter.disable-unbound |
 
 ### Kea DHCPv4
 | Metric Name | Type | Labels                                                                                     | Subsystem | Description                                          | Disable Flag                  |

--- a/internal/collector/unbound_dns.go
+++ b/internal/collector/unbound_dns.go
@@ -8,8 +8,10 @@ import (
 )
 
 type unboundDNSCollector struct {
-	log    *slog.Logger
-	uptime *prometheus.Desc
+	log          *slog.Logger
+	uptime       *prometheus.Desc
+	answerBogus  *prometheus.Desc
+	answerSecure *prometheus.Desc
 
 	subsystem string
 	instance  string
@@ -34,10 +36,20 @@ func (c *unboundDNSCollector) Register(namespace, instanceLabel string, log *slo
 		"Uptime of the unbound DNS service in seconds",
 		nil,
 	)
+	c.answerBogus = buildPrometheusDesc(c.subsystem, "answer_bogus_total",
+		"Total number of responses that failed DNSSEC validation",
+		nil,
+	)
+	c.answerSecure = buildPrometheusDesc(c.subsystem, "answer_secure_total",
+		"Total number of responses that successfully passed DNSSEC validation",
+		nil,
+	)
 }
 
 func (c *unboundDNSCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.uptime
+	ch <- c.answerBogus
+	ch <- c.answerSecure
 }
 
 func (c *unboundDNSCollector) Update(client *opnsense.Client, ch chan<- prometheus.Metric) *opnsense.APICallError {
@@ -49,6 +61,18 @@ func (c *unboundDNSCollector) Update(client *opnsense.Client, ch chan<- promethe
 		c.uptime,
 		prometheus.GaugeValue,
 		float64(data.UptimeSeconds),
+		c.instance,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.answerBogus,
+		prometheus.CounterValue,
+		float64(data.AnswerBogusTotal),
+		c.instance,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		c.answerSecure,
+		prometheus.CounterValue,
+		float64(data.AnswerSecureTotal),
 		c.instance,
 	)
 

--- a/opnsense/unbound_dns.go
+++ b/opnsense/unbound_dns.go
@@ -196,35 +196,39 @@ type UnboundDNSOverview struct {
 	BlocklistSize     int
 	Passed            int
 	AnswerRcodesTotal int
-	AnnswerBogusTotal int
+	AnswerBogusTotal  int
 	AnswerSecureTotal int
 	UptimeSeconds     float64
 }
 
 func (c *Client) FetchUnboundOverview() (UnboundDNSOverview, *APICallError) {
-	var (
-		response      unboundDNSStatusResponse
-		data          UnboundDNSOverview
-		err           error
-		errConvertion *APICallError
-	)
+	var response unboundDNSStatusResponse
 
 	url, ok := c.endpoints["unboundDNSStatus"]
 	if !ok {
-		return data, &APICallError{
+		return UnboundDNSOverview{}, &APICallError{
 			Endpoint:   "unboundDNSStatus",
 			Message:    "endpoint not found in client endpoints",
 			StatusCode: 0,
 		}
 	}
 	if err := c.do("GET", url, nil, &response); err != nil {
-		return data, err
+		return UnboundDNSOverview{}, err
 	}
 
-	data.QueryTypes = make(map[string]int)
-	data.AnswerRcodes = make(map[string]int)
+	return parseUnboundOverview(&response, url)
+}
 
-	data.UptimeSeconds, err = strconv.ParseFloat(response.Data.Time.Up, 64)
+// parseUnboundOverview transforms the raw API response into the
+// collector-facing overview. It is split from FetchUnboundOverview so the
+// parsing logic can be exercised by unit tests without an HTTP round trip.
+func parseUnboundOverview(response *unboundDNSStatusResponse, url EndpointPath) (UnboundDNSOverview, *APICallError) {
+	data := UnboundDNSOverview{
+		QueryTypes:   make(map[string]int),
+		AnswerRcodes: make(map[string]int),
+	}
+
+	uptime, err := strconv.ParseFloat(response.Data.Time.Up, 64)
 	if err != nil {
 		return data, &APICallError{
 			Endpoint:   string(url),
@@ -232,7 +236,10 @@ func (c *Client) FetchUnboundOverview() (UnboundDNSOverview, *APICallError) {
 			StatusCode: 0,
 		}
 	}
-	data.AnnswerBogusTotal, errConvertion = parseStringToInt(response.Data.Num.Answer.Bogus, url)
+	data.UptimeSeconds = uptime
+
+	var errConvertion *APICallError
+	data.AnswerBogusTotal, errConvertion = parseStringToInt(response.Data.Num.Answer.Bogus, url)
 	if errConvertion != nil {
 		return data, errConvertion
 	}

--- a/opnsense/unbound_dns_test.go
+++ b/opnsense/unbound_dns_test.go
@@ -1,0 +1,71 @@
+package opnsense
+
+import "testing"
+
+func TestParseUnboundOverview(t *testing.T) {
+	const endpoint EndpointPath = "/api/unbound/diagnostics/stats"
+
+	t.Run("populated DNSSEC counters", func(t *testing.T) {
+		var resp unboundDNSStatusResponse
+		resp.Data.Time.Up = "12345.678"
+		resp.Data.Num.Answer.Bogus = "3"
+		resp.Data.Num.Answer.Secure = "42"
+
+		got, err := parseUnboundOverview(&resp, endpoint)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.UptimeSeconds != 12345.678 {
+			t.Errorf("UptimeSeconds = %v, want 12345.678", got.UptimeSeconds)
+		}
+		if got.AnswerBogusTotal != 3 {
+			t.Errorf("AnswerBogusTotal = %d, want 3", got.AnswerBogusTotal)
+		}
+		if got.AnswerSecureTotal != 42 {
+			t.Errorf("AnswerSecureTotal = %d, want 42", got.AnswerSecureTotal)
+		}
+		if got.QueryTypes == nil || got.AnswerRcodes == nil {
+			t.Error("QueryTypes / AnswerRcodes maps should be initialized")
+		}
+	})
+
+	t.Run("zero DNSSEC counters", func(t *testing.T) {
+		var resp unboundDNSStatusResponse
+		resp.Data.Time.Up = "0"
+		resp.Data.Num.Answer.Bogus = "0"
+		resp.Data.Num.Answer.Secure = "0"
+
+		got, err := parseUnboundOverview(&resp, endpoint)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.AnswerBogusTotal != 0 || got.AnswerSecureTotal != 0 {
+			t.Errorf("expected zeroed counters, got bogus=%d secure=%d",
+				got.AnswerBogusTotal, got.AnswerSecureTotal)
+		}
+	})
+
+	t.Run("empty uptime returns error", func(t *testing.T) {
+		var resp unboundDNSStatusResponse
+		// Extended Statistics disabled: Time.Up empty, Num.Answer fields zero-value.
+		// Existing behavior should fail loudly so operators see they need to enable it.
+		_, err := parseUnboundOverview(&resp, endpoint)
+		if err == nil {
+			t.Fatal("expected error for empty uptime, got nil")
+		}
+		if err.Endpoint != string(endpoint) {
+			t.Errorf("error endpoint = %q, want %q", err.Endpoint, string(endpoint))
+		}
+	})
+
+	t.Run("empty bogus surfaces parse error", func(t *testing.T) {
+		var resp unboundDNSStatusResponse
+		resp.Data.Time.Up = "1.0"
+		// Bogus left empty — must surface a parse error so the operator sees
+		// the upstream API didn't populate the DNSSEC fields.
+		_, err := parseUnboundOverview(&resp, endpoint)
+		if err == nil {
+			t.Fatal("expected error for empty bogus counter, got nil")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Expose the DNSSEC validation counters that the Unbound client already fetches but the collector never emits. Fixes #107.

Currently `client.FetchUnboundOverview` parses `data.num.answer.bogus` and `data.num.answer.secure` into `UnboundDNSOverview`, but `internal/collector/unbound_dns.go` only emits `opnsense_unbound_dns_uptime_seconds` — the bogus/secure values are dead code on the metric side.

## Changes

- **Expose two new Counter metrics** in the Unbound collector:
  - `opnsense_unbound_dns_answer_bogus_total` — responses that failed DNSSEC validation
  - `opnsense_unbound_dns_answer_secure_total` — responses that successfully passed DNSSEC validation
- **Rename `UnboundDNSOverview.AnnswerBogusTotal`** (triple-n typo) → `AnswerBogusTotal`. The type lives in package `opnsense` with no external consumers — the only caller is the collector in this same repo.
- **Split parsing from HTTP fetch**: introduce private `parseUnboundOverview(response, url)` so the parsing logic can be unit-tested without mocking the HTTP layer. `FetchUnboundOverview` now owns just the network round trip and delegates parsing.
- **Add `opnsense/unbound_dns_test.go`** with 4 subtests:
  - `populated DNSSEC counters` — happy path against typical Extended-Statistics response
  - `zero DNSSEC counters` — newly-restarted Unbound with no traffic yet
  - `empty uptime returns error` — Extended Statistics disabled; preserves existing fail-loud behaviour
  - `empty bogus surfaces parse error` — Extended Statistics partially missing
- **Update `docs/metrics.md`** with the two new metrics.

Prerequisites for the new counters to populate are unchanged — the operator still needs `Services > Unbound DNS > Advanced > Extended Statistics` enabled on OPNsense, already documented in the README under "OPNsense settings".

## Type of change

- [x] Bug fix / dead-code activation (non-breaking)
- [x] New metrics

## How Has This Been Tested?

- [x] `go test ./...` — all packages pass
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on changed files
- [x] Integration test against **OPNsense 26.1.5** with Extended Statistics enabled. Sample output after the patch:

  ```
  opnsense_unbound_dns_uptime_seconds{opnsense_instance="opnsense"} 1234.5
  opnsense_unbound_dns_answer_bogus_total{opnsense_instance="opnsense"} 0
  opnsense_unbound_dns_answer_secure_total{opnsense_instance="opnsense"} 166
  ```

## Checklist

- [x] New unit tests added (`opnsense/unbound_dns_test.go`)
- [x] All existing tests pass
- [x] Metrics documentation updated (`docs/metrics.md`)
- [ ] N/A — no dependency changes

Closes #107
