### PR TITLE
fix(kea-dhcp): tolerate string-serialized lease fields from OPNsense API

### DIFF
--- a/opnsense/json_flex.go
+++ b/opnsense/json_flex.go
@@ -1,0 +1,92 @@
+package opnsense
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// flexInt is an integer that tolerates the inconsistent JSON shapes the
+// OPNsense MVC API uses for numeric Kea lease fields. Depending on the
+// OPNsense release and Kea plugin build, a field such as valid_lifetime,
+// expire, state, subnet_id or pool_id may arrive as a bare JSON number
+// (86400), a quoted number ("86400"), an empty string ("") or null. All of
+// these decode into an int.
+//
+// Bounds: the token is parsed as a signed 64-bit integer. On the
+// linux/amd64 build target int is 64-bit, so every legitimate DHCP lease
+// value fits without truncation -- valid_lifetime tops out at 0xffffffff
+// (4294967295, the "infinite" lease) and expire is a unix timestamp. A
+// value that overflows int64, or any non-numeric token, is returned as an
+// error rather than silently coerced to 0, so a malformed payload surfaces
+// loudly instead of emitting a wrong metric. Empty string and null are
+// treated as a legitimate "absent" value and decode to 0.
+type flexInt int
+
+func (f *flexInt) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 || bytes.Equal(b, []byte("null")) {
+		*f = 0
+		return nil
+	}
+
+	// Unwrap a quoted value -- "86400" -> 86400 -- decoding the JSON string
+	// so any escaping is handled correctly before we parse it.
+	if b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return fmt.Errorf("flexInt: %w", err)
+		}
+		s = strings.TrimSpace(s)
+		if s == "" {
+			*f = 0
+			return nil
+		}
+		b = []byte(s)
+	}
+
+	n, err := strconv.ParseInt(string(b), 10, 64)
+	if err != nil {
+		return fmt.Errorf("flexInt: cannot parse %q as integer: %w", string(b), err)
+	}
+	*f = flexInt(n)
+	return nil
+}
+
+// flexStringSlice is a []string that tolerates the OPNsense MVC API
+// returning the Kea is_reserved field either as a JSON array (["hwaddr"])
+// or as a bare string ("hwaddr" for a reserved lease, "" otherwise). A
+// non-empty string becomes a single-element slice; an empty string or null
+// becomes an empty slice, so callers can keep using len() to detect whether
+// a lease is reserved.
+type flexStringSlice []string
+
+func (s *flexStringSlice) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 || bytes.Equal(b, []byte("null")) {
+		*s = nil
+		return nil
+	}
+
+	if b[0] == '[' {
+		var arr []string
+		if err := json.Unmarshal(b, &arr); err != nil {
+			return fmt.Errorf("flexStringSlice: %w", err)
+		}
+		*s = arr
+		return nil
+	}
+
+	var str string
+	if err := json.Unmarshal(b, &str); err != nil {
+		return fmt.Errorf("flexStringSlice: %w", err)
+	}
+	if strings.TrimSpace(str) == "" {
+		*s = nil
+		return nil
+	}
+	*s = flexStringSlice{str}
+	return nil
+}

--- a/opnsense/json_flex_test.go
+++ b/opnsense/json_flex_test.go
@@ -1,0 +1,100 @@
+package opnsense
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFlexInt(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    flexInt
+		wantErr bool
+	}{
+		{name: "bare number", in: `86400`, want: 86400},
+		{name: "quoted number", in: `"86400"`, want: 86400},
+		{name: "empty string", in: `""`, want: 0},
+		{name: "null", in: `null`, want: 0},
+		{name: "zero string", in: `"0"`, want: 0},
+		{name: "infinite lease", in: `"4294967295"`, want: 4294967295},
+		{name: "non-numeric string", in: `"abc"`, wantErr: true},
+		{name: "array", in: `["x"]`, wantErr: true},
+		{name: "overflow", in: `"99999999999999999999"`, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var f flexInt
+			err := json.Unmarshal([]byte(tt.in), &f)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got value %d", tt.in, f)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.in, err)
+			}
+			if f != tt.want {
+				t.Errorf("flexInt(%q) = %d, want %d", tt.in, f, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlexStringSlice(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantLen int
+	}{
+		{name: "bare string reserved", in: `"hwaddr"`, wantLen: 1},
+		{name: "empty string not reserved", in: `""`, wantLen: 0},
+		{name: "null", in: `null`, wantLen: 0},
+		{name: "array one", in: `["hwaddr"]`, wantLen: 1},
+		{name: "array empty", in: `[]`, wantLen: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var s flexStringSlice
+			if err := json.Unmarshal([]byte(tt.in), &s); err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.in, err)
+			}
+			if len(s) != tt.wantLen {
+				t.Errorf("flexStringSlice(%q) len = %d, want %d", tt.in, len(s), tt.wantLen)
+			}
+		})
+	}
+}
+
+// TestKeaDhcpv4RowAllStringsJSON decodes a lease row in the all-strings shape
+// that OPNsense 26.1.x returns from api/kea/leases4/search -- every numeric
+// field quoted and is_reserved as a bare string. This is the exact payload
+// that made the upstream int/[]string structs fail with
+// "cannot unmarshal string into Go struct field ... valid_lifetime of type int".
+func TestKeaDhcpv4RowAllStringsJSON(t *testing.T) {
+	const payload = `{
+		"if": "igc0", "address": "10.0.0.1", "hwaddr": "c8:9e:43:4e:9f:f6",
+		"client_id": "", "valid_lifetime": "86400", "expire": "1781118374",
+		"subnet_id": "1", "fqdn_fwd": "0", "fqdn_rev": "0", "hostname": "ap",
+		"state": "0", "user_context": "", "pool_id": "0", "if_descr": "LAN",
+		"if_name": "lan", "mac_info": "NETGEAR", "is_reserved": "hwaddr"
+	}`
+
+	var row KeaDhcpv4LeasesRow
+	if err := json.Unmarshal([]byte(payload), &row); err != nil {
+		t.Fatalf("failed to unmarshal all-strings lease row: %v", err)
+	}
+	if row.ValidLifetime != 86400 {
+		t.Errorf("ValidLifetime = %d, want 86400", row.ValidLifetime)
+	}
+	if row.Expiration != 1781118374 {
+		t.Errorf("Expiration = %d, want 1781118374", row.Expiration)
+	}
+	if row.State != 0 || row.SubnetId != 1 || row.PoolId != 0 {
+		t.Errorf("state/subnet/pool = %d/%d/%d, want 0/1/0", row.State, row.SubnetId, row.PoolId)
+	}
+	if len(row.IsReserved) != 1 {
+		t.Errorf("IsReserved len = %d, want 1 (reserved)", len(row.IsReserved))
+	}
+}

--- a/opnsense/kea_dhcpv4.go
+++ b/opnsense/kea_dhcpv4.go
@@ -1,23 +1,23 @@
 package opnsense
 
 type KeaDhcpv4LeasesRow struct {
-	If                   string   `json:"if"`
-	Address              string   `json:"address"`
-	Hwaddr               string   `json:"hwaddr"`
-	ClientId             string   `json:"client_id"`
-	ValidLifetime        int      `json:"valid_lifetime"`
-	Expiration           int      `json:"expire"`
-	InterfaceDescription string   `json:"if_descr"`
-	InterfaceName        string   `json:"if_name"`
-	MacInfo              string   `json:"mac_info"`
-	IsReserved           []string `json:"is_reserved"`
-	Hostname             string   `json:"hostname"`
-	FqdnForward          string   `json:"fqdn_fwd"`
-	FqdnReceived         string   `json:"fqdn_rev"`
-	State                int      `json:"state"`
-	UserContext          string   `json:"user_context"`
-	SubnetId             int      `json:"subnet_id"`
-	PoolId               int      `json:"pool_id"`
+	If                   string          `json:"if"`
+	Address              string          `json:"address"`
+	Hwaddr               string          `json:"hwaddr"`
+	ClientId             string          `json:"client_id"`
+	ValidLifetime        flexInt         `json:"valid_lifetime"`
+	Expiration           flexInt         `json:"expire"`
+	InterfaceDescription string          `json:"if_descr"`
+	InterfaceName        string          `json:"if_name"`
+	MacInfo              string          `json:"mac_info"`
+	IsReserved           flexStringSlice `json:"is_reserved"`
+	Hostname             string          `json:"hostname"`
+	FqdnForward          string          `json:"fqdn_fwd"`
+	FqdnReceived         string          `json:"fqdn_rev"`
+	State                flexInt         `json:"state"`
+	UserContext          string          `json:"user_context"`
+	SubnetId             flexInt         `json:"subnet_id"`
+	PoolId               flexInt         `json:"pool_id"`
 }
 
 type KeaDhcpv4LeasesResponse struct {
@@ -66,8 +66,8 @@ func parseDHCPv4Leases(response KeaDhcpv4LeasesResponse) (KeaDhcpv4Leases, *APIC
 			data.ReservedLeaseCount[row.InterfaceName] += 1
 		}
 
-		expiration := row.Expiration
-		lifetime := row.ValidLifetime
+		expiration := int(row.Expiration)
+		lifetime := int(row.ValidLifetime)
 
 		// Add the information in
 		data.Leases = append(data.Leases, KeaDhcpv4Lease{

--- a/opnsense/kea_dhcpv6.go
+++ b/opnsense/kea_dhcpv6.go
@@ -1,27 +1,27 @@
 package opnsense
 
 type KeaDhcpv6LeasesRow struct {
-	If                    string   `json:"if"`
-	Address               string   `json:"address"`
-	Hwaddr                string   `json:"hwaddr"`
-	Duid                  string   `json:"duid"`
-	ValidLifetime         int      `json:"valid_lifetime"`
-	Expiration            int      `json:"expire"`
-	InterfaceDescription  string   `json:"if_descr"`
-	InterfaceName         string   `json:"if_name"`
-	IsReserved            []string `json:"is_reserved"`
-	Hostname              string   `json:"hostname"`
-	FqdnForward           string   `json:"fqdn_fwd"`
-	FqdnReceived          string   `json:"fqdn_rev"`
-	State                 int      `json:"state"`
-	UserContext           string   `json:"user_context"`
-	SubnetId              string   `json:"subnet_id"`
-	PoolId                string   `json:"pool_id"`
-	PreferredLifetime     int      `json:"pref_lifetime"`
-	Iaid                  string   `json:"iaid"`
-	PrefixLength          int      `json:"prefix_len"`
-	HardwareType          string   `json:"hwtype"`
-	HardwareAddressSource string   `json:"hwaddr_source"`
+	If                    string          `json:"if"`
+	Address               string          `json:"address"`
+	Hwaddr                string          `json:"hwaddr"`
+	Duid                  string          `json:"duid"`
+	ValidLifetime         flexInt         `json:"valid_lifetime"`
+	Expiration            flexInt         `json:"expire"`
+	InterfaceDescription  string          `json:"if_descr"`
+	InterfaceName         string          `json:"if_name"`
+	IsReserved            flexStringSlice `json:"is_reserved"`
+	Hostname              string          `json:"hostname"`
+	FqdnForward           string          `json:"fqdn_fwd"`
+	FqdnReceived          string          `json:"fqdn_rev"`
+	State                 flexInt         `json:"state"`
+	UserContext           string          `json:"user_context"`
+	SubnetId              string          `json:"subnet_id"`
+	PoolId                string          `json:"pool_id"`
+	PreferredLifetime     flexInt         `json:"pref_lifetime"`
+	Iaid                  string          `json:"iaid"`
+	PrefixLength          flexInt         `json:"prefix_len"`
+	HardwareType          string          `json:"hwtype"`
+	HardwareAddressSource string          `json:"hwaddr_source"`
 }
 
 type KeaDhcpv6LeasesResponse struct {
@@ -73,10 +73,10 @@ func parseDHCPv6Leases(leases KeaDhcpv6LeasesResponse) (KeaDhcpv6Leases, *APICal
 			data.ReservedLeaseCount[row.InterfaceName] += 1
 		}
 
-		expiration := row.Expiration
-		lifetime := row.ValidLifetime
-		preferredLifetime := row.PreferredLifetime
-		prefixLength := row.PrefixLength
+		expiration := int(row.Expiration)
+		lifetime := int(row.ValidLifetime)
+		preferredLifetime := int(row.PreferredLifetime)
+		prefixLength := int(row.PrefixLength)
 
 		// Add the information in
 		data.Leases = append(data.Leases, KeaDhcpv6Lease{


### PR DESCRIPTION
## Description

`v0.0.16` (#105) aligned the Kea lease structs to an OPNsense build that returns the numeric lease fields as bare JSON numbers and `is_reserved` as a JSON array. **OPNsense 26.1.5** returns all of those numeric fields (`valid_lifetime`, `expire`, `state`, `subnet_id`, `pool_id`) as JSON **strings** and `is_reserved` as a bare **string**, so `encoding/json` aborts on the first field and the `kea_dhcpv4` / `kea_dhcpv6` collectors emit no metrics (see #110).

This makes the affected fields tolerant of **both** serializations via two small custom unmarshalers in the `opnsense` package:

- `flexInt` — accepts a JSON number, a quoted number, `""` or `null` (the last two decode to `0`); returns an error only on genuinely non-numeric or overflowing input.
- `flexStringSlice` — accepts `is_reserved` as either `["hwaddr"]` or a bare `"hwaddr"` / `""` string, so the existing `len()`-based reservation count is unchanged.

The numeric Kea struct fields switch from `int` to `flexInt` and `is_reserved` from `[]string` to `flexStringSlice`; the parse functions convert back to `int` at the existing call sites. No new metrics, no dependency/vendor changes, and no behavior change for boxes that already worked (bare numbers and array `is_reserved` still parse).

Fixes #110

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added table-driven unit tests for `flexInt` and `flexStringSlice`, plus a regression test (`TestKeaDhcpv4RowAllStringsJSON`) that decodes a real OPNsense 26.1.5 all-strings `leases4` row.
- `go test ./...` — all green (existing Kea tests still pass).
- `gofmt -s` — clean; `golangci-lint run` (v2, as in CI) — 0 issues.
- Built the image and ran it against a live OPNsense 26.1.5 box: the `kea_dhcpv4` collector now exports all leases (previously zero) and the per-scrape unmarshal error is gone.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
